### PR TITLE
paq8px_v141fix3+fix4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,1116 @@
+---------------
+VERSION HISTORY
+---------------
+
+Newest entries are at the bottom.
+Dates are in YYYY.MM.DD format.
+
+
+DIFFERENCES FROM PAQ7
+
+An .exe model and filter are added.  Context maps are improved using 16-bit
+checksums to reduce collisions.  The state table uses probabilistic updates
+for large counts, more states that remember the last bit, and decreased
+discounting of the opposite count.  It is implemented as a fixed table.
+There are also many minor changes.
+
+DIFFERENCES FROM PAQ8A
+
+The user interface supports directory compression and drag and drop.
+The preprocessor segments the input into blocks and uses more robust
+EXE detection.  An indirect context model was added.  There is no
+dictionary preprocesor like PAQ8B/C/D/E.
+
+DIFFERENCES FROM PAQ8F
+
+Different models, usually from paq8hp*. Also changed rate from 8 to 7. A bug
+in Array was fixed that caused the program to silently crash upon exit.
+
+DIFFERENCES FROM PAQ8J
+
+1) Slightly improved sparse model.
+2) Added new family of sparse contexts. Each byte mapped to 3-bit value, where
+different values corresponds to different byte classes. For example, input
+byte 0x00 transformed into 0, all bytes that less then 16 -- into 5, all
+punctuation marks (ispunct(c)!=0) -- into 2 etc. Then this flags from 11
+previous bytes combined into 32-bit pseudo-context.
+
+All this improvements gives only 62 byte on BOOK1, but on binaries archive size
+reduced on 1-2%.
+
+DIFFERENCES FROM PAQ8JA
+
+Introduced distance model. Distance model uses distance to last occurence
+of some anchor char (0x00, space, newline, 0xff), combined with previous
+charactes as context. This slightly improves compression of files with
+variable-width record data.
+
+DIFFERENCES FROM PAQ8JB
+
+Restored recordModel(), broken in paq8hp*. Slightly tuned indirectModel().
+
+DIFFERENCES FROM PAQ8JC
+
+Changed the APMs in the Predictor. Up to a 0.2% improvement for some files.
+
+DIFFERENCES FROM PAQ8JD
+
+Added DMCModel.  Removed some redundant models from SparseModel and other
+minor tuneups.  Changes introduced in PAQ8K were not carried over.
+
+PAQ8L v.2
+
+Changed Mixer::p() to p() to fix a compiler error in Linux
+(patched by Indrek Kruusa, Apr. 15, 2007).
+
+DIFFERENCES FROM PAQ8L, PAQ8M
+
+Modified JPEG model by Jan Ondrus (paq8fthis2).  The new model improves
+compression by using decoded pixel values of current and adjacent blocks
+as context.  PAQ8M was an earlier version of the new JPEG model
+(from paq8fthis).
+
+DIFFERENCES FROM PAQ8N
+
+Improved bmp model. Slightly faster.
+
+DIFFERENCES FROM PAQ8O
+
+Modified JPEG model by Jan Ondrus (paq8fthis4).
+Added PGM (grayscale image) model form PAQ8I.
+Added grayscale BMP model to PGM model.
+Ver. 2 can be compiled using either old or new "for" loop scoping rules.
+Added APM and StateMap from LPAQ1
+Code optimizations from Enrico Zeidler
+Detection of BMP 4,8,24 bit and PGM 8 bit images before compress
+On non BMP,PGM,JPEG data mem is lower
+Fixed bug in BMP 8-bit detection in other files like .exe
+15. oct 2007
+Updates JPEG model by Jan Ondrus
+PGM detection bug fix
+22. oct 2007
+improved JPEG model by Jan Ondrus
+16. feb 2008
+fixed bmp detection bug
+added .rgb file support (uncompressed grayscale)
+
+DIFFERENCES FROM PAQ8O9
+
+Added wav Model. Slightly improved bmp model.
+
+DIFFERENCES FROM PAQ8P (i.e. PAQ8PX is born)
+
+pap8px_v0
+2009.04.25
+- Added nestModel from paq8p3
+- Modified wordModel from paq8p3
+- Modified .pbm, .pgm, .ppm, .bmp, .rgb detection (from paq8p3)
+- Modified WAV model (from paq8p_)
+- Modified JPEG model (from paq8p2)
+- Added im1bitModel (1-bit) (from paq8p3)
+- Added compression of PPM, PBM images (from paq8p3)
+- Removed pic model
+
+
+pap8px_v1
+2009.04.26
+- Fixed "Transform fails at 79385" when compressiong WcgopFsd.dll
+- A fix for properly compressing partially currupted images (e.g. 2359362 bytes 1024x768 bitmap)
+- JPEG model wasn't replaced in previous version
+
+
+pap8px_v2
+2009.04.29
+- Fixed bug in pgm/pbm/ppm detection.
+
+
+pap8px_v4
+2009.05.01
+- There was a problem with compressing files larger than 1 block (512MB for -7 switch, 4MB for -0 swtich). Fixed.
+
+
+pap8px_v5
+2009.05.04
+- Small modifications in exe detection and e8/e9 exe filter
+
+
+pap8px_v6
+2009.05.05
+- fixed: compressing using -8 switch was broken
+- fixed: you could use (not working) -9 switch in previous versions
+
+
+pap8px_v7
+2009.05.07
+- Same fix as done for paqp3. Bmp detection for negative height was broken
+
+
+pap8px_v8
+2009.05.07
+- Some code modified in 1-bit/8-bit/24-bit BMP detection (compression size is different only for 1-bit BMPs = was wrong starting offset in old version)
+
+
+pap8px_v9
+2009.05.08
+- now there are only im24bitModel, im8bitModel and im1bitModel instead of im24bitModel, pgmModel, bmpModel8, rgbModel8, bmpModel1 and pbmModel
+- all image header detection is removed from models (only place for image detection is detect procedure)
+- every image is divided into 2 blocks - IMAGEHDR (header) and IMAGEx (where x is 1, 8 or 24)
+- there are additional 8 bytes in compressed stream (for size of IMAGEHDR block and for image width)
+- experimental improved tiff detection (should detect uncompressed tiff created by IrfanView)
+- RGB detection can detect images with more chanels (3 or 4) - chanels are compressed independently using im8bitModel (IMAGE8 block)
+- during compression can't be printed such info BMP(width x height), instead of it program prints info about blocks: blocktype(size in bytes)
+
+
+pap8px_v10
+2009.05.08
+- Added 24-bit tga compression
+- Added More checks for Tiff
+- Added 1-bit Tiff compression
+- Changed many if[...]if[...] to if[...]else if[...] in detect
+- Fixed compiling error with MSVC++ because of unknown abs type
+
+
+pap8px_v11
+2009.05.09
+- Fixed parsing the tga header.
+
+
+pap8px_v12
+2009.05.09
+-fixed bug in TGA detection
+-some code changed in BMP,RGB and TIFF detection
+
+
+pap8px_v13
+2009.05.09
+- fixed: monochrome TGA works again
+- some code modified in TIFF detection
+
+
+pap8px_v14
+2009.05.10
+- uncompressed audio 8-bit/16-bit mono/stereo is now compressed in separate AUDIO blocks
+- wave file is divided into HDR and AUDIO block (images into HDR and IMAGEx)
+- extra information (like width for images) saved in compressed stream is BitsPerSample+Channels (possible values are 9, 10, 17, 18)
+- found and fixed problem for images blocks - metadata (=size of block, image width) were compressed using special models (image models)
+
+
+pap8px_v15
+2009.05.10
+- fixed: WAVE detection can skip metadata now
+
+
+pap8px_v16
+2009.05.12
+- fixed JPEG detection
+
+
+pap8px_v17
+2009.05.12
+- removed file segmenting by BLOCKS=MEM*128 (as is in paq8p3) -> entire file is processed as one block
+- some source code cleaning (removed some spaces and tabs)
+- int wavmodel changed to void wavmodel (not returning value)
+
+
+pap8px_v18
+2009.05.12
+- increased tolerance for TIFF files (start of raw image data) from 64kb to 256kb
+- experimental MOD file detection and compression
+
+
+pap8px_v19
+2009.05.12
+- fixed bug in MOD detection (broken detecting files with 64 patterns) + more MODs can be recognized (those marked with M.K. 8CHN 6CHN FLT4 or FLT8)
+
+
+pap8px_v20
+2009.05.12
+- ?
+
+pap8px_v21
+2009.05.16
+- changed some code in wavmodel to improve its speed (no compression ratio changes)
+
+
+pap8px_v22
+2009.05.18
+- fixed bug in wavmodel
+
+
+pap8px_v23
+2009.05.19
+- added experimental S3M modules detection
+
+
+pap8px_v24
+2009.05.19
+- fixed bug in S3M detection (one variable wasn't properly initialized).
+
+
+pap8px_v25
+2009.05.19
+- different handling of 8-bit WAVE data. (samples were interpreted as number 0..255 in previous versions -> current version -128..127) -> improves compression on most files
+
+
+pap8px_v26
+2009.05.20
+- Block segmentation information is printed before actual compression starts.
+- Percentage is displayed during compression.
+
+
+pap8px_v27
+2009.05.20
+- Merged void encode and void compress procedures.
+- Block segmentation information is printed during compression now.
+
+
+pap8px_v28
+2009.05.20
+- fixed: string "Compressing..." was printed twice because of default block with size=0 in between jpeg blocks.
+
+
+pap8px_v29
+2009.05.21
+- Changed the structure of the compress function a lot. It now stops using encode_default instead it compresses directly from input file.
+  In files without EXE data there is no temporary file anymore and surely also no comparing.
+
+
+pap8px_v30
+2009.05.21
+- Removed some redundant code from compress procedure
+- Added direct_encode_block() procedure for repeated task in compress() procedure
+
+
+pap8px_v31
+2009.05.21
+- added experimental AIFF detection and compression
+- some small modification in handling 8-bit audio data (wavmodel)
+
+
+pap8px_v32
+2009.05.22
+- Fixed bug in wavmodel.
+- You can use -0 to -3 switch for faster wave compression now
+
+
+pap8px_v32
+2009.05.22
+- fixed another bug (fix from v32 wasn't optimal for some files)
+
+
+pap8px_v34
+2009.05.22
+- Improved AIFF detection.
+
+
+pap8px_v35
+2009.05.23
+- Improved AIFF detection - can skip padding byte correctly
+- Corrected handling with 8-bit audio in AIFF format
+- Max size of extra blocks before sound data in AIFF is 1024 now
+
+
+pap8px_v36
+2009.05.26
+- Removed two writes (and reads) of size of exe-block
+- Changes in sparseModel, exeModel, indirectModel, nestModel which should improve compression of executables a bit
+
+
+pap8px_v37
+2009.05.28
+- improved exe filter - relative to absolute address conversion is now performed also for conditional jumps (for 0x0f80..0x0f8f instructions)
+
+
+pap8px_v38
+2009.05.30
+- Experimental detection and transformation of CD sectors in CD images(only type #1) as done in ECM -> sequence of sectors is detected as new block type : cd
+- Functions for computing ECC and EDC are taken from UNECM decoder (GPL) by Neill Corlett
+- Ro test detection/transformation you can use -0 switch
+
+
+pap8px_v39
+2009.05.30
+- Fixed bug: conflict in CD and EXE detection (exe detected inside cd image could cause bad things)
+
+
+pap8px_v40
+2009.05.30
+- limited maximal size of cd block to 38535168 (16384 sectors) so larger cd images are divided into more blocks and user can see progress
+
+
+pap8px_v41
+2009.05.30
+- disabled detecting anything else when CD is detected.
+
+
+pap8px_v42
+2009.05.30
+- fixed bug: special models for special blocks (image/audio) wasn't used when found after CD block due to wrong/missing size of encoded cd block calculation.
+
+
+pap8px_v43
+2009.06.01
+- improved CD sectors transformation - addresses are not saved which improves efficiency of transformation and allow possibility for future detection images/audio inside CD image data
+
+
+pap8px_v44
+2009.06.01
+- fixed bug: wrong size of encoded CD block
+
+
+pap8px_v45
+2009.06.01
+- detection images/audio/exe/cd/jpeg blocks inside transformed cd block data
+- works recursively (maximal deep of recursion is set to 5 - controlled by #define MAX_ITER 5)
+- each CD block now contains subblocks
+- meaning of percentage is changed - it shows progress for individual block (i think this is bad and will try to return previous behavior in next versions)
+
+
+pap8px_v46
+2009.06.02
+- added support for CD-ROM Mode 2 XA (CD-ROM/XA) Form 1 (2352 bytes) sectors
+- percentage shows again progress for entire files
+
+
+pap8px_v47
+2009.06.03
+- added support for mode 2/form 2 CD sectors (experimental)
+- fixed bug in recursion
+- fixed bug with wrong detection of special block types in first CD sector
+
+
+pap8px_v48
+2009.06.04
+- fixed bug in encoding exe blocks: block header was written twice which caused that exeModel was not used
+
+
+pap8px_v49
+2009.06.04
+- fixed bug: wrong percentage when more files were compressed
+
+
+pap8px_v50
+2009.06.05
+- improved detection exe code
+
+
+pap8px_v51
+2009.06.05
+- fixed bug in decode()
+
+
+pap8px_v52
+2009.06.05
+- fixed: in detect() "cdm" has never been initialized
+
+
+pap8px_v53
+2009.06.06
+- changed xor-parameter of exe transformation (old: 64=01000000, new: 176=10110000) -> three bytes of absolute adress are xored using this value before encoding
+
+
+pap8px_v54
+2009.06.11
+- added new decompression system from Simon Berger/paq8q
+- new style of block segmentation information during compression
+
+
+pap8px_v55
+2009.06.13
+- new version of wavModel
+- recordModel is no longer used inside wavModel which may lead to increased speed and small loss in compression ratio.
+
+
+pap8px_v56
+2009.06.13
+- before value from sum is used it is coverted to float:  sum=float(sum);
+
+
+pap8px_v57
+2009.06.13
+- converting to float wasn't good idea - this could hurt compression ratio very much -> instead of it sum is rounded in this version: sum=round(sum);
+
+
+pap8px_v58
+2009.06.17
+- changed end of exe-block detection (size of no x86 code increased from 4kb to 16kb)
+- minor changes in block information output
+
+
+pap8px_v59
+2009.06.19
+- Added internal C99 compliant round() function. Compile with '-DLPROUND_ON' to enable.
+
+
+pap8px_v60
+2009.06.20
+- improved wavModel
+  1.) Replaced round(sum) with floor(sum+0.5)
+  2.) Some changes in contexts (improving compression)
+  3.) RecordModel is used in wavModel again (because it improves compression mainly for 8bit audio)
+
+
+pap8px_v61
+2009.06.25
+- Added a simple color transformation to paq8px. All detected 24-bit image data are transformed. Different formats have diferent color order RGB (.tiff) vs. BGR (.bmp) -> this could cause different compression for the same image in different formats.
+
+
+pap8px_v62
+2009.08.16
+- some double brackets removed
+- fixed some compiler warnings
+
+
+pap8px_v63
+2009.08.16
+- fixed additional -Wparentheses compiler warnings 
+
+
+pap8px_v64
+2009.08.16
+- fixed warnings produced by -DNOASM and -O2 switches in GCC 4.4.0
+
+
+pap8px_v65
+2009.10.28
+- fixed bug: compression/transformation of 24-bit images in BMP format with width not divisible by 4
+
+
+pap8px_v66
+2009.10.29
+- fixed bug: when comparing 24-bit image wrong difference position could be reported
+- improved 24-bit image model
+
+
+pap8px_v67
+2009.11.05
+- changes in Mixer initialization and context
+- changes in indirectModel and nestModel
+
+
+pap8px_v68
+2010.01.18
+- file list / archive header is compressed
+- you can list archive contents with -l switch
+
+
+pap8px_v69
+2010.04.26
+- problem with compressing files in different paths fixed.
+
+
+pap8px_v70
+2016.03.09
+- added zlib recompression from AntiZ (it probably has lot of bugs and can crash randomly)
+
+
+pap8px_v71
+2016.03.11
+- fixed bug with special image/audio models broken by zlib recompression
+- fixed bug with wrong progress display
+- some changes in recompressed zlib data header
+- added pdfimage support
+
+
+pap8px_v72
+2016.03.19
+- Added base64 transform (from paq8pxd)
+- Modified im8bitModel (8-bit) (from paq8pxd)
+- Added gif recompression
+
+
+pap8px_v73
+2016.03.19
+- Fixed a bug in base64 transform
+
+
+pap8px_v74
+2016.03.20
+- model changes from paq8pxd
+- fix bugs in gif detection/recompression
+
+
+pap8px_v75
+2016.03.22
+- fixed gif routines ("Transform fails")
+
+
+pap8px_v76
+2017.07.09
+- improved JPEG model to allow it to account for sub-sampling
+
+
+pap8px_v77
+2017.07.10
+- modified the record model (new heuristic for checking the candidate lengths, and a new context, both derived from EMMA's record model).
+- modified the BMP parsing code to detect embedded DIB's in executable files.
+
+
+pap8px_v77b
+2017.07.10
+- fixed a small error in the code
+- added 2 new contexts from EMMA to the record model.
+
+
+pap8px_v78
+2017.07.15
+- Changed the JPEG model to be able to detect embedded thumbnails and to compress MJPEG video frames (by loading the default huffman tables).
+- The recursion level on the thumbnail detection can be configured by a simple constant change, currently it can detect a thumbnail within a thumbnail.
+- Added 5 contexts from my grayscale 8bpp model in EMMA to the 8bpp and 24bpp models in paq8px.
+
+
+pap8px_v79
+2017.07.17
+- Modified the 24bpp image model to also be able to compress 32bpp images, to be able to account for padding in BMP/DIB images, and changed one of its mixer contexts. 
+- Changed a mixer context for the 8bpp image model.
+
+
+pap8px_v80
+2017.07.23
+- Fixed the JPEG thumbnail detection bug and other bugs in previous versions.
+- Modified the record model.
+
+
+pap8px_v81
+2017.07.24
+- This version detects if a 8bpp image is grayscale or a color-palette image by parsing the color table, if available 
+  (for PGM files a grayscale image is assumed, the check is made for BMP/DIB and TGA images). 
+  This is done because their characteristics are completely different, so they require different approaches.
+- Modified the 8bpp image model to account for both variants, 
+- And added 5 simple contexts for the color-palette branch. 
+- Modified a global mixer context, it should give better compression on executable files.
+
+
+pap8px_v82
+2017.07.25
+- Made a few simple tweaks to the JPEG model, compression is now even closer to that of EMMA.
+
+
+pap8px_v83
+2017.07.25
+- small changes in jpegmodel
+
+
+pap8px_v84
+2017.07.25
+- Fixed problems in JPEG model.
+- Added a new context to the 24/32bpp image model
+- Made a few simple tweaks to the audio model.
+
+
+pap8px_v85
+2017.07.27
+- Small changes in jpegmodel
+
+
+pap8px_v86
+2017.07.28
+- Added 2 new contexts in jpegmodel
+- Fixed the grayscale detection routine.
+
+
+pap8px_v87
+2017.07.28
+- adjustments of new contexts in jpeg model
+
+
+pap8px_v88
+2017.08.04
+- additional small jpeg model improvements
+
+
+pap8px_v89
+2017.08.05
+- a few quick tweaks to the jpeg model contexts, and added a new context.
+
+
+pap8px_v90
+2017.08.08
+- added few more small tweaks to jpeg model
+
+
+pap8px_v91
+2017.08.11
+- Small changes to the word model, 24/32bpp image model and the JPEG model
+
+
+pap8px_v92
+2017.08.12
+- more jpeg model tweaks
+
+
+pap8px_v93
+2017.08.15
+- fixed issue with maxpc.pdf (thanks for reporting Stephan Busch)
+
+
+pap8px_v94
+2017.08.16
+- fixed issue with VirtualAlloc and VirtualFree when compiling on Mac OSX 
+- improvements to the nest model
+- slight tweak to the exe model
+
+
+pap8px_v95
+2017.08.16
+- added PAM format detection, 32bit-image transformation
+
+
+pap8px_v96
+2017.08.17
+- fixed the bug in the initialization of the number of mixer inputs.
+- added a new experimental model for XML, similar to the one in EMMA. 
+
+
+pap8px_v97
+2017.08.17
+- bug fixes (thank you Mauro)
+- improvements to the XML model
+- detects audio in SoundFont .SF2 files.
+
+
+pap8px_v98
+2017.08.18
+- This version features a new and much improved x86/x64 model, based on a blending of the old model,
+  DisFilter by Fabian Giesen (http://www.farbrausch.de/~fg/code/disfilter/) and the x86/x64 model in EMMA.
+
+
+pap8px_v99
+2017.08.19
+- fixed a few more bugs and made some improvements to the exe model.
+- removed all code that made the complexity of the models dependent on the compression level
+
+
+pap8px_v100
+2017.08.23
+- Fixed a bug in the exe model
+- made the .PAM image parser case-insensitive, just in case some images weren't being detected.
+- added 2 contexts from EMMA in the 24/32bpp image model.
+
+
+pap8px_v101
+2017.08.26
+- a small change to allow paq8px to compress JPEG images created by guetzli
+
+
+pap8px_v102
+2017.08.29
+- Improved the x86/x64 model and the 1bpp image model, and fixed a few bugs.
+- The BMP/DIB detection should now handle icons and cursors better
+- The PDF parser now handles 1bpp images compressed with Deflate and distinguishes 8bpp grayscale images from 8bpp indexed-color images.
+
+
+pap8px_v103
+2017.08.31
+- Made a few improvements to the wordModel, 
+- Created a model for 4bpp images, which are very common in executables.
+
+
+pap8px_v104
+2017.09.02
+- This version can recompress some 24/32bpp PNG images with a proper image model.
+- Modified the existing 24/32bpp image model to also compress the filtered PNG pixel data.
+- Created a few example contexts designed to model such data
+- Tweaked the existing (non-PNG, unfiltered pixel data) model a bit.
+
+
+pap8px_v105
+2017.09.03
+- simplified block type handling routines
+- because we now have 4-bit image model we should use it for 4-bit pdf image (we used here the 8-bit model instead)
+
+
+pap8px_v106
+2017.09.04
+- Improved the 24/32bpp PNG image model. 
+- Improved the parsers for WAV and TGA.
+- The GIF parser now detects if the image is grayscale by analysing the global color palette.
+
+
+pap8px_v107
+2017.09.04
+- Enabled 8bpp PNG recompression with the 8bpp image model.
+- Improved the 24/32bpp image model.
+
+
+pap8px_v108
+2017.09.06
+- Made variants of the 8bpp image model to handle 8bpp PNG images, both grayscale and indexed color.
+- Improved the 24/32bpp image model, both the normal and the PNG variants.
+
+
+pap8px_v109
+2017.09.07
+- Improved the 24/32bpp image model (both variants, PNG or not), along with the grayscale 8bpp model (also both variants).
+- The JPEG model is now called also on header blocks, to allow the detection of some embedded thumbnails in some TIF\RAW images.
+
+
+pap8px_v110
+2017.09.08
+- Merged the 8bpp image model indexed color variants (both PNG and non-PNG) and made a few improvements to it.
+
+
+pap8px_v111
+2017.09.09
+- Deleted the old 8bpp grayscale model that was being used for non-PNG images and modified the PNG variant to do both.
+- Improved the new 8bpp image model so this is now a completely new model, both for grayscale and color-indexed images, PNG or not.
+- Improved the 24/32bpp image model, also both PNG or not.
+- created a new model for modelling stationary (or nearly so) data
+
+
+pap8px_v112
+2017.09.17
+- Pre-training of x86/x64 model with the compiled binary itself
+- Pre-training of part of the main model with file "english.dic", if present (optional)
+- Improved StationaryMap
+- Improved 24/32bpp and 8bpp grayscale image models
+
+
+pap8px_v113
+2017.10.10
+- improved the 24/32bpp image model, both for PNG and non-PNG images.
+
+
+pap8px_v114
+2017.10.15
+- Made a few more improvements to the 24/32bpp image model, especially on the PNG variant.
+- The 8bpp color-indexed model is also slightly improved.
+- The heuristic for the record model now attempts to detect 24bpp images, and the model now uses 2 contexts for 8bpp and 24bpp images. This helps on images that aren't detected by the parsers, such as Tif images.
+
+
+pap8px_v115
+2017.10.21
+- Improved the record model 
+- Made a few tweaks to the DMC model.
+
+
+pap8px_v116
+2017.10.22
+- Bug fixes in DMC model reported by Mauro
+
+
+paq8px_v117 
+2017.10.29
+- Fixes assertion failed errors reported by Mauro:
+  - Line 897 : Expression: i>0
+  - Line 1957: Expression: (((unsigned long long)cp[i])&63)>=15
+  - Line 1226: Expression: p>=0 && p<4096
+
+paq8px_v118
+2017.11.01
+- Bugfixes in recordModel, wordModel, and the 8bpp image model 
+- Improvements to the record model, the 8bpp and the 24/32bpp image models
+
+
+paq8px_v119
+2017.11.04
+- Improved the 8bpp and 24/32bpp image models
+- Modified the DEFLATE transform to use a Move-To-Front list to keep the possible zlib parameter combinations ranked by recency and to break as soon as a perfect match is found.
+
+
+paq8px_v120 
+2017.11.12
+- Implemented a brute-force mode for detection of DEFLATE streams
+- Fixed a small bug in the DIB detection code.
+- No models were improved
+
+
+paq8px_v121
+2017.11.26
+- Fixed incorrect scaling in StationaryMap
+- Fixed a bug in pdf detection (zbuf[])
+- Made both pre-training modes and also the brute-force DEFLATE stream detection optional.
+- No model improvements
+
+
+paq8px_v121_fixed1
+2017.12.05
+- Fixed a MS Visual C++ 2015 optimization issue in im24bitModel (division by zero)
+- Fixed two minor bugs in class Array
+- Fixed a bug in class zLibMTF
+- Fixed access denied error when creating temporary files on Windows
+- Fixed some #defines in order to compile properly with MS Visual C++
+- Eliminated all Visual C++ 2015 compiler warnings (W3) and most MinGW-w64 compiler warnings
+- Removed "-level[switches] archive files..." from help screen
+- No model or compression improvements
+
+
+paq8px_v121_fixed2
+2017.12.09
+- Fixed ilog2 (in recordModel)
+- Created an MSVC variant for ilog2
+- HashTable: fixed its code to match its documentation (h([i] should return p+i+1, not p+i), updated its references (in im4bitModel)
+- HashTable: revised documentation to understand it easier (hopefully)
+- SmallStationaryContextMap: changed implementation to be more intuitive (hopefully)
+- im24bitModel: minor details in code were changed to be more intuitive (hopefully) and removed the unused scm10 and Map[29] contextmaps
+- im8bitModel: minor details in code were changed to be more intuitive (hopefully)
+- wavModel: rewritten 1) to use Array 2) peeled 2 expressions from loops 3) changed minor details in code to be more intuitive (hopefully)
+- No model or compression improvements
+
+
+paq8px_v121_fixed3
+2017.12.09
+- Fixed im24bitModel: put back scm10 and Map[29] contextmaps (erroneously removed in paq8px_v121_fixed2).
+- Clip, Climp4, LogMeanDiffQt: modified code to be more intuitive (hopefully)
+- No model or compression improvements
+
+
+paq8px_v122
+2017.12.18
+- dmcModel: applied the patch from Mauro
+- jpegModel: set a faster learning rate
+- code(): instead of increasing all lower probabilities ( p+=p<2048; ) we simply forbid only p=0; ( if(p==0)p++; )
+
+
+paq8px_v123
+2017.12.18
+- Small improvements to the 24/32bpp image model (PNG and non-PNG variants)
+- Adaptive learning rate, available through an optional switch
+
+
+paq8px_v124 
+2017.12.19
+- Improved 8bpp grayscale model (PNG and non-PNG variants)
+- Record model now detects and parses dBASE tables
+
+
+paq8px_v125
+2017.12.23
+- Improved 8bpp grayscale image model, slightly improved 24/32bpp image model
+- Changes to the zlib transform:
+  - Fixed bug when zlib doesn't produce any output when using Z_NO_FLUSH
+  - Early break when no more combinations are left to try, skipping decompression of the remaining stream
+- Optional switch to skip the 24/32bpp RGB color transform and only perform channel reordering
+
+
+paq8px_v126 
+2017.12.26
+- Improved IO functions (tmpfile)
+  - Temporary files are kept in memory
+  - Windows MSVCRT root folder "access denied" issue is fixed properly with true temporary files
+- No model or compression improvements
+
+
+paq8px_v127 
+2017.12.29
+- Experimental English stemmer
+- Tweaked StationaryMap, added a new context to the 24/32bpp image model
+
+
+paq8px_v128 
+2017.01.02
+- Improved 8bpp grayscale image model (PNG and non-PNG variants)
+- Tweaked SmallStationaryMap
+
+
+paq8px_v129 
+2017.01.09
+- Slightly improved 24/32bpp image model (PNG and non-PNG variants)
+- Horizontal symmetries search for 8bpp model
+- New context map and hash table, used in the main model only
+- Bug fixes in Array class
+
+
+paq8px_v129_fix1 
+2017.01.13
+- Fixed "error: use of deleted function" in gcc in Array class (v114-129) reported by Mauro
+- Sanity check in makedir function
+- Changed "rb+" to "rb" in FileDisk.open() to enable compressing read-only files
+- Assert failed in FileTmp.blockwrite() during zlib decompression when count was 0 and asserts were on (it caused no problems otherwise in release mode); fixed in both blockread() and blockwrite()
+- Assert failed in FileTmp.setpos() when IMAGE8 bmp detection calculated a "detd" value larger than the actual block. Fixed in setpos(); will try to isolate it to let it fix in detect() as well.
+- Minor fixes in doc and/or code (Buf, IntBuf, Mixer, ContextMap, matchModel, ContextModel)
+- im24bitModel: reverted undesired Visual Studio autoformatting
+- No model or compression improvements (archives must be binary compatible with paq8px_v129) 
+
+
+paq8px_v129_fix2
+2017.01.14
+- fixed redefinition warning for NOMINMAX (when compiling with newer MinGW-w64 versions)
+- fixed a couple of "misleading-indentation" (in Mixer) and "suggest parentheses" warnings (in ContextModel) (when compiling with MinGW-w64)
+- fixed a "comparison between signed and unsigned integer expressions" warning in ContextMapB64 (when compiling with MinGW-w64)
+- fixed the printf() format specifier in Array.chkindex()
+- enabled the use of compression level 9 (using 3348 MB RAM)
+- removed dependency on compression level in wavModel
+- fixed seeking past end of file problems in FileTmp class 
+
+
+paq8px_v130 
+2017.01.14
+- Created a new ContextMap variant merging features from both previous variants. 
+
+
+paq8px_v130_fix1 
+2017.01.17
+- Fixed 4 asserts: assert(true) -> assert(false)
+- Fixed decode_cd(): dealing with the "residual" data was buggy
+- Removed unnecessary includes
+- Corrected comments here and there
+- Heavily commented expand_cd_sector(), encode_cd() and decode_cd() functions
+
+
+paq8px_v130_fix2 
+2017.01.18
+- On decompression the following message was printed: "FileDisk: unable to open file (No such file or directory)". Fixed.
+- Printing more info when FileDisk.create() or FileDisk.createtmp() fails for any reason (name of the file and error: access denied, filen not found, etc.)
+- Cosmetic fixes in remarks and/or code (Array's chkindex, IntBuf, jpegModel, Encoder, detect(), etc.)
+- No model or compression improvements
+
+
+paq8px_v131 
+2017.01.21
+- Refactored new ContextMap, now used on the exeModel also
+- Text pre-training now performs 3 iterations on the dictionary (word list) file, and also trains on an optional expression list file
+- New context for the 8bpp grayscale image model
+
+
+paq8px_v132 
+2017.01.25
+- Restored linux compatibility.
+- Eliminated some compiler warnings.
+- A little cleanup here and there.
+- No model or compression improvements
+
+
+paq8px_v132_fix1 
+2017.01.27
+- Fixed (finalized) exception handling
+- Removed some unnecessary #includes, organised the remaining ones and explained PRIu64
+- Separated platform-specific logic from ContextModel::Train() and exeModel::Train(){
+- Fixed a "pass thru" bug in FileTmp::blockwrite()
+- No model or compression improvements
+
+
+paq8px_v133 
+2017.01.28
+- Refactored stemming routines
+- New French stemmer (currently unused)
+- English stemmer now handles "non/non-" prefixes
+
+
+paq8px_v134
+2017.02.03
+- Implemented dot_product() and train() in AVX2
+- Fixes for proper Mac OSX compilation
+
+
+paq8px_v135 
+2017.02.04
+- New experimental text model with language detection via stemming/common word lists, currently using only one context
+- Text pre-training now uses the RunContextMaps
+- Code refactoring
+
+
+paq8px_v136 
+2017.02.11
+- Improved text model
+
+
+paq8px_v137 
+2017.02.14
+- Fixed some compatibility issues with older compilers
+- Changed some [] arrays to Array<> in order to detect out of bound operations
+- Now you can disable/enable compilation of certain models/transformations (ZLIB, TEXTMODEL, WORDMODEL, WAVMODEL)
+- The "String" class is extended with new functions to support the new command line interface
+- A new "FileName" class to represent a filename/filepath.
+- Introduced some file/folder helper functions (examinepath(), getfilesize(), appendtofile(), isoutputredirected() - see source)
+- Dispatcher for SSE2/AVX2 neural network functions
+- Remark: needed to switch jpegmodel from function to class for the new CPU-dispatched Mixer.
+- Improvements - for users
+  - Archive names are now generated by adding the full version (e.g. .paq8px137) to the input filename.
+  - Archives are now comparable - based solely on their content regardless of the input filename and path
+  - Input filename and its path is not stored in the archive anymore.
+  - Wildcard support and folder compression is removed for the sake of a list-based file enumeration.
+  - If you wish to compress more files, you'll have to gather the filenames (with optional relative paths) in a text file.
+  - When compressing multiple files you may now save extra information about those files (date, permissions,
+    file attributes, even your own remarks). But you have to gather it yourself. See the help screen for more info.
+  - All "Windows drag and drop" support is removed:
+  - No pause and no "Close this window or press ENTER to continue..." message at the end.
+  - Output file is not created automatically in the folder of the input file. It is created in the current folder or in the folder you specify.
+  - Removed default compression level "5" (it was part of the drag-and-drop support). Now you have to specify the compression level explicitly.
+  - Separated the ambiguous -d command line switch to -d (decompress) and -t (test)
+  - Now you can log compression results (size, time, memory, command line options) in a logfile (use the -log command line switch).
+  - SSE2/AVX2 dot product and training is now contained in the same executable. The executable runs on "all" CPUs.
+  - After launch it detects the vectorization support, which you can override from the command line.
+  - In decompression/testing mode you can now print the command options used for compression (use the -v (verbose) command line switch).
+  - If screen output is redirected to a file then "onscreen" information is printed without the progress indicator -> no garbage in the captured output.
+  - The optional compression switches (b/e/t/a/s) come after the compression level without the brackets.
+  - You can give the command line parameters in any order you want. Only the order of the input and output specification is a must (obviously).
+  - Rewritten help screen
+
+
+paq8px_v137_fix1 
+2017.02.15
+- Fixed: missing space on helpscreen ("filewhere")
+- Fixed: problem in multiple file mode when parsing the listfile (code for tab was incorrect) 
+
+
+paq8px_v138 
+2017.02.15
+- A small improvement to the new text model 
+
+
+paq8px_v138_e1w3fix
+2017.02.24
+- Fixing 1 error and 3 warnings that happen while building v138 on Linux.
+
+
+paq8px_v139
+2017.02.25
+- Slightly improved text model
+- French stemmer nows handles UTF8 Unicode code points common to that language
+
+
+paq8px_v140 
+2017.02.27
+- Slightly improved text model
+- New german stemmer
+
+
+paq8px_v141
+2017.03.08
+- Tuned the adaptive learning rates in Mixer
+
+
+paq8px_v141fix1
+2018.04.11
+- Fixed a bug in the stemmers reported by Mauro - gcc incorrectly optimized memcpys believing that the memory ranges do not overlap when the -ftree-vrp flag was 'on' (it is 'on' by default on -O2 and higher)
+- Fixed some minor bugs and typos
+- Print the selected vectorization info only if the user wants/needs to know.
+- On single file mode (almost) the same information was printed 3 times on screen (input file size). Now it prints it only twice (at the beginning of segmentation and in the summary) like in the old days.
+- Fixed wording (bytes vs size) - thank you, Darek.
+- No model or compression improvements
+
+
+pap8px_v141fix2
+2018.04.18
+- Restored clang (linux) compatibility (changed gcc pragmas to function attributes for the dot product and train functions)
+- Fixed compiler warnings
+- Fixed a bug in decode_gif() (1st part of a while condition was always true)
+- Fixed a bug in main() (value of 'options' was never EOF)
+- JpegModel reserved memory always (even if this model was not used). Fixed.
+- Until now we didn't know the overhead (the size of the added "diff" information) of zlib recompression. Now we know. It is printed on screen along with the segmentation information.
+- No model or compression improvements
+
+
+pap8px_v141fix3
+2018.04.19
+- Separated documentation from the source file (README, DOC, CHANGELOG)
+- Updated (rewrote) README
+- Gathered CHANGELOG information
+- No code changes
+
+
+pap8px_v141fix4
+2018.04.23
+- Cosmetic changes in the documents
+  - README: is now UTF8 encoded for having non-ascii characters + small changes in the text
+  - DOC: added warning that contents are partially obsolete
+  - source file: a bit clearer header
+- Small changes/fixes in Word, Language, TextModel and the English Stemmer classes
+  - Added virtual destructors
+  - Created a function to print the result of the stemmer (i.e. word stem) for debugging
+  - Fixed 2 items in the Exceptions1 list (idle, gentle)
+  - Fixed a bug in Step5 ( W->End+=!EndsInShortSyllable(W);  ->  W->End+=EndsInShortSyllable(W); )
+  - Modified TrimStartingApostrophe() to trim more than 1 apostrophe both from the beginning and end in pairs
+  - Commented some parts of the English Stemming routines
+- Finally fixed the printf formatting warnings in Linux/GCC and Linux/Clang (changed typedef shortcuts for U8..U64)

--- a/DOC
+++ b/DOC
@@ -1,0 +1,323 @@
+- Warning: parts of this document are obsolete or incomplete - 
+
+----------------
+PAQ8PX INTERNALS
+----------------
+
+ARITHMETIC CODING
+
+The binary data is arithmetic coded as the shortest base 256 fixed point
+number x = SUM_i x_i 256^-1-i such that p(<y) <= x < p(<=y), where y is the
+input string, x_i is the i'th coded byte, p(<y) (and p(<=y)) means the
+probability that a string is lexicographcally less than (less than
+or equal to) y according to the model, _ denotes subscript, and ^ denotes
+exponentiation.
+
+The model p(y) for y is a conditional bit stream,
+p(y) = PROD_j p(y_j | y_0..j-1) where y_0..j-1 denotes the first j
+bits of y, and y_j is the next bit.  Compression depends almost entirely
+on the ability to predict the next bit accurately.
+
+
+MODEL MIXING
+
+paq8px uses a neural network to combine a large number of models.  The
+i'th model independently predicts
+p1_i = p(y_j = 1 | y_0..j-1), p0_i = 1 - p1_i.
+The network computes the next bit probabilty
+
+  p1 = squash(SUM_i w_i t_i), p0 = 1 - p1                        (1)
+
+where t_i = stretch(p1_i) is the i'th input, p1_i is the prediction of
+the i'th model, p1 is the output prediction, stretch(p) = ln(p/(1-p)),
+and squash(s) = 1/(1+exp(-s)).  Note that squash() and stretch() are
+inverses of each other.
+
+After bit y_j (0 or 1) is received, the network is trained:
+
+  w_i := w_i + eta t_i (y_j - p1)                                (2)
+
+where eta is an ad-hoc learning rate, t_i is the i'th input, (y_j - p1)
+is the prediction error for the j'th input but, and w_i is the i'th
+weight.  Note that this differs from back propagation:
+
+  w_i := w_i + eta t_i (y_j - p1) p0 p1                          (3)
+
+which is a gradient descent in weight space to minimize root mean square
+error.  Rather, the goal in compression is to minimize coding cost,
+which is -log(p0) if y = 1 or -log(p1) if y = 0.  Taking
+the partial derivative of cost with respect to w_i yields (2).
+
+
+MODELS
+
+Most models are context models.  A function of the context (last few
+bytes) is mapped by a lookup table or hash table to a state which depends
+on the bit history (prior sequence of 0 and 1 bits seen in this context).
+The bit history is then mapped to p1_i by a fixed or adaptive function.
+There are several types of bit history states:
+
+- Run Map. The state is (b,n) where b is the last bit seen (0 or 1) and
+  n is the number of consecutive times this value was seen.  The initial
+  state is (0,0).  The output is computed directly:
+
+    t_i = (2b - 1)K log(n + 1).
+
+  where K is ad-hoc, around 4 to 10.  When bit y_j is seen, the state
+  is updated:
+
+    (b,n) := (b,n+1) if y_j = b, else (y_j,1).
+
+- Stationary Map.  The state is p, initially 1/2.  The output is
+  t_i = stretch(p).  The state is updated at ad-hoc rate K (around 0.01):
+
+    p := p + K(y_j - p)
+
+- Nonstationary Map.  This is a compromise between a stationary map, which
+  assumes uniform statistics, and a run map, which adapts quickly by
+  discarding old statistics.  An 8 bit state represents (n0,n1,h), initially
+  (0,0,0) where:
+
+    n0 is the number of 0 bits seen "recently".
+    n1 is the number of 1 bits seen "recently".
+    n = n0 + n1.
+    h is the full bit history for 0 <= n <= 4,
+      the last bit seen (0 or 1) if 5 <= n <= 15,
+      0 for n >= 16.
+
+  The primaty output is t_i := stretch(sm(n0,n1,h)), where sm(.) is
+  a stationary map with K = 1/256, initialized to
+  sm(n0,n1,h) = (n1+(1/64))/(n+2/64).  Four additional inputs are also
+  be computed to improve compression slightly:
+
+    p1_i = sm(n0,n1,h)
+    p0_i = 1 - p1_i
+    t_i   := stretch(p_1)
+    t_i+1 := K1 (p1_i - p0_i)
+    t_i+2 := K2 stretch(p1) if n0 = 0, -K2 stretch(p1) if n1 = 0, else 0
+    t_i+3 := K3 (-p0_i if n1 = 0, p1_i if n0 = 0, else 0)
+    t_i+4 := K3 (-p0_i if n0 = 0, p1_i if n1 = 0, else 0)
+
+  where K1..K4 are ad-hoc constants.
+
+  h is updated as follows:
+    If n < 4, append y_j to h.
+    Else if n <= 16, set h := y_j.
+    Else h = 0.
+
+  The update rule is biased toward newer data in a way that allows
+  n0 or n1, but not both, to grow large by discarding counts of the
+  opposite bit.  Large counts are incremented probabilistically.
+  Specifically, when y_j = 0 then the update rule is:
+
+    n0 := n0 + 1, n < 29
+          n0 + 1 with probability 2^(27-n0)/2 else n0, 29 <= n0 < 41
+          n0, n = 41.
+    n1 := n1, n1 <= 5
+          round(8/3 lg n1), if n1 > 5
+
+  swapping (n0,n1) when y_j = 1.
+
+  Furthermore, to allow an 8 bit representation for (n0,n1,h), states
+  exceeding the following values of n0 or n1 are replaced with the
+  state with the closest ratio n0:n1 obtained by decrementing the
+  smaller count: (41,0,h), (40,1,h), (12,2,h), (5,3,h), (4,4,h),
+  (3,5,h), (2,12,h), (1,40,h), (0,41,h).  For example:
+  (12,2,1) 0-> (7,1,0) because there is no state (13,2,0).
+
+- Match Model.  The state is (c,b), initially (0,0), where c is 1 if
+  the context was previously seen, else 0, and b is the next bit in
+  this context.  The prediction is:
+
+    t_i := (2b - 1)Kc log(m + 1)
+
+  where m is the length of the context.  The update rule is c := 1,
+  b := y_j.  A match model can be implemented efficiently by storing
+  input in a buffer and storing pointers into the buffer into a hash
+  table indexed by context.  Then c is indicated by a hash table entry
+  and b can be retrieved from the buffer.
+
+
+CONTEXTS
+
+High compression is achieved by combining a large number of contexts.
+Most (not all) contexts start on a byte boundary and end on the bit
+immediately preceding the predicted bit.  The contexts below are
+modeled with both a run map and a nonstationary map unless indicated.
+
+- Order n.  The last n bytes, up to about 16.  For general purpose data.
+  Most of the compression occurs here for orders up to about 6.
+  An order 0 context includes only the 0-7 bits of the partially coded
+  byte and the number of these bits (255 possible values).
+
+- Sparse.  Usually 1 or 2 of the last 8 bytes preceding the byte containing
+  the predicted bit, e.g (2), (3),..., (8), (1,3), (1,4), (1,5), (1,6),
+  (2,3), (2,4), (3,6), (4,8).  The ordinary order 1 and 2 context, (1)
+  or (1,2) are included above.  Useful for binary data.
+
+- Text.  Contexts consists of whole words (a-z, converted to lower case
+  and skipping other values).  Contexts may be sparse, e.g (0,2) meaning
+  the current (partially coded) word and the second word preceding the
+  current one.  Useful contexts are (0), (0,1), (0,1,2), (0,2), (0,3),
+  (0,4).  The preceding byte may or may not be included as context in the
+  current word.
+
+- Formatted text.  The column number (determined by the position of
+  the last linefeed) is combined with other contexts: the charater to
+  the left and the character above it.
+
+- Fixed record length.  The record length is determined by searching for
+  byte sequences with a uniform stride length.  Once this is found, then
+  the record length is combined with the context of the bytes immediately
+  preceding it and the corresponding byte locations in the previous
+  one or two records (as with formatted text).
+
+- Context gap.  The distance to the previous occurrence of the order 1
+  or order 2 context is combined with other low order (1-2) contexts.
+
+- FAX.  For 2-level bitmapped images.  Contexts are the surrounding
+  pixels already seen.  Image width is assumed to be 1728 bits (as
+  in calgary/pic).
+
+- Image.  For uncompressed 24-bit color BMP, TIFF and TGA images.  Contexts
+  are the high order bits of the surrounding pixels and linear
+  combinations of those pixels, including other color planes.  The
+  image width is detected from the file header.  When an image is
+  detected, other models are turned off to improve speed.
+
+- JPEG.  Files are further compressed by partially uncompressing back
+  to the DCT coefficients to provide context for the next Huffman code.
+  Only baseline DCT-Huffman coded files are modeled.  (This ia about
+  90% of images, the others are usually progresssive coded).  JPEG images
+  embedded in other files (quite common) are detected by headers.  The
+  baseline JPEG coding process is:
+  - Convert to grayscale and 2 chroma colorspace.
+  - Sometimes downsample the chroma images 2:1 or 4:1 in X and/or Y.
+  - Divide each of the 3 images into 8x8 blocks.
+  - Convert using 2-D discrete cosine transform (DCT) to 64 12-bit signed
+    coefficients.
+  - Quantize the coefficients by integer division (lossy).
+  - Split the image into horizontal slices coded independently, separated
+    by restart codes.
+  - Scan each block starting with the DC (0,0) coefficient in zigzag order
+    to the (7,7) coefficient, interleaving the 3 color components in
+    order to scan the whole image left to right starting at the top.
+  - Subtract the previous DC component from the current in each color.
+  - Code the coefficients using RS codes, where R is a run of R zeros (0-15)
+    and S indicates 0-11 bits of a signed value to follow.  (There is a
+    special RS code (EOB) to indicate the rest of the 64 coefficients are 0).
+  - Huffman code the RS symbol, followed by S literal bits.
+  The most useful contexts are the current partially coded Huffman code
+  (including S following bits) combined with the coefficient position
+  (0-63), color (0-2), and last few RS codes.
+
+- Match.  When a context match of 400 bytes or longer is detected,
+  the next bit of the match is predicted and other models are turned
+  off to improve speed.
+
+- Exe.  When a x86 file (.exe, .obj, .dll) is detected, sparse contexts
+  with gaps of 1-12 selecting only the prefix, opcode, and the bits
+  of the modR/M byte that are relevant to parsing are selected.
+  This model is turned off otherwise.
+
+- Indirect.  The history of the last 1-3 bytes in the context of the
+  last 1-2 bytes is combined with this 1-2 byte context.
+
+- DMC. A bitwise n-th order context is built from a state machine using
+  DMC, described in http://plg.uwaterloo.ca/~ftp/dmc/dmc.c
+  The effect is to extend a single context, one bit at a time and predict
+  the next bit based on the history in this context.  The model here differs
+  in that two predictors are used.  One is a pair of counts as in the original
+  DMC.  The second predictor is a bit history state mapped adaptively to
+  a probability as as in a Nonstationary Map.
+
+ARCHITECTURE
+
+The context models are mixed by several of several hundred neural networks
+selected by a low-order context.  The outputs of these networks are
+combined using a second neural network, then fed through several stages of
+adaptive probability maps (APM) before arithmetic coding.
+
+For images, only one neural network is used and its context is fixed.
+
+An APM is a stationary map combining a context and an input probability.
+The input probability is stretched and divided into 32 segments to
+combine with other contexts.  The output is interpolated between two
+adjacent quantized values of stretch(p1).  There are 2 APM stages in series:
+
+  p1 := (p1 + 3 APM(order 0, p1)) / 4.
+  p1 := (APM(order 1, p1) + 2 APM(order 2, p1) + APM(order 3, p1)) / 4.
+
+PREPROCESSING
+
+paq8px uses preprocessing transforms on certain data types to improve
+compression.  To improve reliability, the decoding transform is
+tested during compression to ensure that the input file can be
+restored.  If the decoder output is not identical to the input file
+due to a bug, then the transform is abandoned and the data is compressed
+without a transform so that it will still decompress correctly.
+
+The input is split into blocks with the format <type> <decoded size> <data>
+where <type> is 1 byte (0 = no transform), <decoded size> is the size
+of the data after decoding, which may be different than the size of <data>.
+Blocks do not span file boundaries, and have a maximum size of 4MB to
+2GB depending on compression level.  Large files are split into blocks
+of this size.  The preprocessor has 3 parts:
+
+- Detector.  Splits the input into smaller blocks depending on data type.
+
+- Coder.  Input is a block to be compressed.  Output is a temporary
+  file.  The coder determines whether a transform is to be applied
+  based on file type, and if so, which one.  A coder may use lots
+  of resources (memory, time) and make multiple passes through the
+  input file.  The file type is stored (as one byte) during compression.
+
+- Decoder.  Performs the inverse transform of the coder.  It uses few
+  resorces (fast, low memory) and runs in a single pass (stream oriented).
+  It takes input either from a file or the arithmetic decoder.  Each call
+  to the decoder returns a single decoded byte.
+
+The following transforms are used:
+
+- EXE:  CALL (0xE8) and JMP (0xE9) address operands are converted from
+  relative to absolute address.  The transform is to replace the sequence
+  E8/E9 xx xx xx 00/FF by adding file offset modulo 2^25 (signed range,
+  little-endian format).  Data to transform is identified by trying the
+  transform and applying a crude compression test: testing whether the
+  byte following the E8/E8 (LSB of the address) occurred more recently
+  in the transformed data than the original and within 4KB 4 times in
+  a row.  The block ends when this does not happen for 4KB.
+
+- JPEG: detected by SOI and SOF and ending with EOI or any nondecodable
+  data.  No transform is applied.  The purpose is to separate images
+  embedded in execuables to block the EXE transform, and for a future
+  place to insert a transform.
+
+
+IMPLEMENTATION
+
+Hash tables are designed to minimize cache misses, which consume most
+of the CPU time.
+
+Most of the memory is used by the nonstationary context models.
+Contexts are represented by 32 bits, possibly a hash.  These are
+mapped to a bit history, represented by 1 byte.  The hash table is
+organized into 64-byte buckets on cache line boundaries.  Each bucket
+contains 7 x 7 bit histories, 7 16-bit checksums, and a 2 element LRU
+queue packed into one byte.  Each 7 byte element represents 7 histories
+for a context ending on a 3-bit boundary plus 0-2 more bits.  One
+element (for bits 0-1, which have 4 unused bytes) also contains a run model
+consisting of the last byte seen and a count (as 1 byte each).
+
+Run models use 4 byte hash elements consisting of a 2 byte checksum, a
+repeat count (0-255) and the byte value.  The count also serves as
+a priority.
+
+Stationary models are most appropriate for small contexts, so the
+context is used as a direct table lookup without hashing.
+
+The match model maintains a pointer to the last match until a mismatching
+bit is found.  At the start of the next byte, the hash table is referenced
+to find another match.  The hash table of pointers is updated after each
+whole byte.  There is no checksum.  Collisions are detected by comparing
+the current and matched context in a rotating buffer.

--- a/README
+++ b/README
@@ -1,0 +1,172 @@
+
+                              PAQ8PX README
+
+---------
+COPYRIGHT
+---------
+
+    Copyright (C) 2008 Matt Mahoney, Serge Osnach, Alexander Ratushnyak,
+    Bill Pettis, Przemyslaw Skibinski, Matthew Fite, wowtiger, Andrew Paterson,
+    Jan Ondrus, Andreas Morphis, Pavel L. Holoborodko, Kaido Orav, Simon Berger,
+    Neill Corlett, Márcio Pais, Andrew Epstein, Mauro Vezzosi, Zoltán Gotthardt
+
+    We would like to express our gratitude for the endless support of many 
+    contributors who encouraged PAQ8PX development with ideas, testing, 
+    compiling, debugging:
+    LovePimple, Skymmer, Darek,  Stephan Busch, m^2, Christian Schneider,
+    pat357, Rugxulo, Gonzalo, a902cd23, pinguin2 - and many others.
+
+-------
+LICENCE
+-------
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of
+    the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details at
+    Visit <http://www.gnu.org/copyleft/gpl.html>.
+
+
+    For a summary of your rights and obilgations in plain laguage visit 
+    https://tldrlegal.com/license/gnu-general-public-license-v2
+
+-----
+ABOUT
+-----
+
+PAQ is a series of experimental lossless data compression software that have gone 
+through collaborative development to top rankings on several benchmarks measuring 
+compression ratio (although at the expense of speed and memory usage).
+
+PAQ8PX (this branch) is one of the longest living branch of the PAQ series started 
+by Jan Ondrus in 2009.
+For history and current state of development visit https://encode.ru/threads/342-paq8px
+
+-----------------
+HOW DOES IT WORK?
+-----------------
+
+Data compression is carried out by compressing the input file(s) bit by bit using 
+context mixing i.e. mixing predictions from many models. For a longer (technical) 
+explanation see the DOC file.
+
+---------------
+PAQ8PX ARCHIVES
+---------------
+
+A PAQ8PX archive contains files in a highly compressed format.
+
+You can recognize a PAQ8PX archive from its file extension. The file extension reflects 
+the exact PAQ8PX version that created the archive. You may also examine the first few
+bytes of the file. If it reads "paq8px" than it is (most probably) a PAQ8PX archive. 
+Exact version information cannot be inferred from the archive content.
+
+A PAQ8PX archive may contain multiple files, but once created, you cannot
+add to or remove files from the archive.
+
+In single file mode (i.e. when compressing just one file) only file contents are 
+stored. File paths, file names, creation or modification dates, file attributes, 
+permissions and other metadata are not preserved. In multiple file mode however, 
+you may store such metadata in the archive (see the help screen for more details).
+
+Notes on pre-training:
+(1)
+ The exe pre-training function (see the command line flag "e") uses the paq8px.exe 
+ file itself to pre-train the exe prediction model, so expect the resulting archives 
+ to be different created by two different paq8px.exe executables - even when built
+ with the same command line options from the same source. When the exe is different, 
+ the predictions will be slightly different, thus the archives will be (completely) 
+ different. As a result you must have the very executable that created an archive in
+ order to extract its contents when you use this pre-training option.
+ 
+(2)
+ If you use the text pre-training function (see the command line flag "t"), the 
+ word list (english.dic) and expression list (english.exp) files are only used for 
+ pre-training the prediction model before the actual file compression would begin.
+ However their content is not stored in the archive. Since these files are required 
+ to pre-train the model before decompression as well, you will need to have them
+ when extracting files from your archive.
+
+More notes:
+Files and archives larger than 2 GB are not (yet) supported.
+PAQ8PX archives are not compatible with previous or future PAQ8PX releases.
+
+----------
+HOW TO USE
+----------
+
+This software is portable, you don't need to install it.
+
+You may copy paq8px.exe to the folder where your files to be compressed are located
+and launch PAQ8PX from the command line (cmd.exe in Windows, a terminal of your choice 
+in Linux and macOS). 
+
+----------------------
+COMMAND LINE INTERFACE
+----------------------
+
+A graphical user interface is not provided, PAQ8PX runs from the command line.
+See the help screen for command line options.
+For the help screen just launch PAQ8PX from the command line without any options.
+
+--------------
+HOW TO COMPILE
+--------------
+
+If you are a Windows user you don't need to compile the source. Just grab the 
+executable bundled with the source from the https://encode.ru/threads/342-paq8px thread.
+
+If you are a Linux or macOS user, you will need to build the binary from source.
+You will need:
+  - the PAQ8PX source file (paq8px*.cpp),
+  - zlib
+  - a compiler.
+
+The following compilers were tested and verified to work correctly in this release 
+or in an earlier release:
+
+  - Visual Studio 2017 Community Edition (Windows)
+  - MinGW-w64 7.1.0 and 7.2.0 (Windows)
+  - GCC 7.3.0 (macOS)
+  - GCC 7.2.0 (Ubuntu)
+  - clang 4.0.1-6 on (Ubuntu)
+
+Note:
+
+ We build and test 64-bit releases, 32-bit releases are seldom built or tested. A known
+ limitation of 32-bit releases is the 2 GB memory barrier. As a consequence, compression 
+ and decompression will not work on level 9 and you may experience "out of memory" errors 
+ on level 8 where memory consumption is near the 2 GB limit.
+
+gcc users on Linux/macOS may use the following commands to make a quick build (albeit with 
+optimal parameters) targeted for their system (note the "-march=native" parameter):
+
+ sudo apt-get install build-essential
+ sudo apt-get install zlib1g-dev
+ g++ -s -fno-rtti -fwhole-program -static -std=gnu++1z -O3 -m64 -march=native -Wall -floop-strip-mine -funroll-loops -ftree-vectorize -fgcse-sm -fprofile-use paq8px.cpp -opaq8px.exe -lz 
+
+Remark: if the paq8px source file name includes version information (e.g. paq8px_v142.cpp) 
+then rename it to "paq8px.cpp" before invoking gcc or change the file name in the 
+gcc parameters to include the version information.
+
+For detailed building instructions visit:
+https://encode.ru/threads/2885-PAQ8PX-building-instructions
+
+--------------
+FOR DEVELOPERS
+--------------
+
+When you make a new release:
+
+  - Please update the version number in the "Versioning" section in the source file.
+  - Please append a short description of your modifications to the CHANGELOG file.
+  - Always publish a static build (link the required dll files statically).
+  - Always publish a build for the general public (e.g. don't use -march=native).
+  - Before publishing your build, please carry out some basic tests. Run your tests
+    with asserts on (see the "#define NDEBUG" line in the "Debug options" section 
+    in the source file).

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -1,605 +1,14 @@
-/* paq8px file compressor/archiver.  Released on April 18, 2018
-
-    Copyright (C) 2008 Matt Mahoney, Serge Osnach, Alexander Ratushnyak,
-    Bill Pettis, Przemyslaw Skibinski, Matthew Fite, wowtiger, Andrew Paterson,
-    Jan Ondrus, Andreas Morphis, Pavel L. Holoborodko, Kaido Orav, Simon Berger,
-    Neill Corlett, Márcio Pais, Mauro Vezzosi, Zoltán Gotthardt
-
-    LICENSE
-
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License as
-    published by the Free Software Foundation; either version 2 of
-    the License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful, but
-    WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    General Public License for more details at
-    Visit <http://www.gnu.org/copyleft/gpl.html>.
-
-To install and use in Windows:
-
-- To install, put paq8px.exe or a shortcut to it on your desktop.
-- To compress a file or folder, drop it on the paq8px icon.
-- To decompress, drop a .paq8px file on the icon.
-
-A .paq8px extension is added for compression, removed for decompression.
-The output will go in the same folder as the input.
-
-While paq8px is working, a command window will appear and report
-progress.  When it is done you can close the window by pressing
-ENTER or clicking [X].
-
-
-COMMAND LINE INTERFACE
-
-- To install, put paq8px.exe somewhere in your PATH.
-- To compress:      paq8px [-N] file1 [file2...]
-- To decompress:    paq8px [-d] file1.paq8px [dir2]
-- To view contents: more < file1.paq8px
-
-The compressed output file is named by adding ".paq8px" extension to
-the first named file (file1.paq8px).  Each file that exists will be
-added to the archive and its name will be stored without a path.
-The option -N specifies a compression level ranging from -0
-(fastest) to -9 (smallest).  The default is -5.  If there is
-no option and only one file, then the program will pause when
-finished until you press the ENTER key (to support drag and drop).
-If file1.paq8px exists then it is overwritten.
-
-If the first named file ends in ".paq8px" then it is assumed to be
-an archive and the files within are extracted to the same directory
-as the archive unless a different directory (dir2) is specified.
-The -d option forces extraction even if there is not a ".paq8px"
-extension.  If any output file already exists, then it is compared
-with the archive content and the first byte that differs is reported.
-No files are overwritten or deleted.  If there is only one argument
-(no -d or dir2) then the program will pause when finished until
-you press ENTER.
-
-For compression, if any named file is actually a directory, then all
-files and subdirectories are compressed, preserving the directory
-structure, except that empty directories are not stored, and file
-attributes (timestamps, permissions, etc.) are not preserved.
-During extraction, directories are created as needed.  For example:
-
-  paq8px -4 c:\tmp\foo bar
-
-compresses foo and bar (if they exist) to c:\tmp\foo.paq8px at level 4.
-
-  paq8px -d c:\tmp\foo.paq8px .
-
-extracts foo and compares bar in the current directory.  If foo and bar
-are directories then their contents are extracted/compared.
-
-There are no commands to update an existing archive or to extract
-part of an archive.  Files and archives larger than 2GB are not
-supported (but might work on 64-bit machines, not tested).
-File names with nonprintable characters are not supported (spaces
-are OK).
-
-
-TO COMPILE
-
-There are 2 files: paq8px.cpp (C++) and paq7asm.asm (NASM/YASM).
-paq7asm.asm is the same as in paq7 and paq8x.  paq8px.cpp recognizes the
-following compiler options:
-
-  -DWINDOWS           (to compile in Windows)
-  -DUNIX              (to compile in Unix, Linux, Solairs, MacOS/Darwin, etc)
-  -DNOASM             (to replace paq7asm.asm with equivalent C++)
-  -DDEFAULT_OPTION=N  (to change the default compression level from 5 to N).
-
-If you compile without -DWINDOWS or -DUNIX, you can still compress files,
-but you cannot compress directories or create them during extraction.
-You can extract directories if you manually create the empty directories
-first.
-
-Use -DEFAULT_OPTION=N to change the default compression level to support
-drag and drop on machines with less than 256 MB of memory.  Use
--DDEFAULT_OPTION=4 for 128 MB, 3 for 64 MB, 2 for 32 MB, etc.
-
-Use -DNOASM for non x86-32 machines, or older than a Pentium-MMX (about
-1997), or if you don't have NASM or YASM to assemble paq7asm.asm.  The
-program will still work but it will be slower.  For NASM in Windows,
-use the options "--prefix _" and either "-f win32" or "-f obj" depending
-on your C++ compiler.  In Linux, use "-f elf".
-
-Recommended compiler commands and optimizations:
-
-  MINGW g++:
-    g++ paq8px.cpp -DWINDOWS -lz -Wall -Wextra -O3 -static -static-libgcc -opaq8px.exe
-
-
-ARCHIVE FILE FORMAT
-
-An archive has the following format.  It is intended to be both
-human and machine readable.  The header ends with CTRL-Z (Windows EOF)
-so that the binary compressed data is not displayed on the screen.
-
-  paq8px -N CR LF
-  size TAB filename CR LF
-  size TAB filename CR LF
-  ...
-  CTRL-Z
-  compressed binary data
-
--N is the option (-0 to -9), even if a default was used.
-Plain file names are stored without a path.  Files in compressed
-directories are stored with path relative to the compressed directory
-(using UNIX style forward slashes "/").  For example, given these files:
-
-  123 C:\dir1\file1.txt
-  456 C:\dir2\file2.txt
-
-Then
-
-  paq8px archive \dir1\file1.txt \dir2
-
-will create archive.paq8px with the header:
-
-  paq8px -5
-  123     file1.txt
-  456     dir2/file2.txt
-
-The command:
-
-  paq8px archive.paq8px C:\dir3
-
-will create the files:
-
-  C:\dir3\file1.txt
-  C:\dir3\dir2\file2.txt
-
-Decompression will fail if the first 7 bytes are not "paq8px -".  Sizes
-are stored as decimal numbers.  CR, LF, TAB, CTRL-Z are ASCII codes
-13, 10, 9, 26 respectively.
-
-
-ARITHMETIC CODING
-
-The binary data is arithmetic coded as the shortest base 256 fixed point
-number x = SUM_i x_i 256^-1-i such that p(<y) <= x < p(<=y), where y is the
-input string, x_i is the i'th coded byte, p(<y) (and p(<=y)) means the
-probability that a string is lexicographcally less than (less than
-or equal to) y according to the model, _ denotes subscript, and ^ denotes
-exponentiation.
-
-The model p(y) for y is a conditional bit stream,
-p(y) = PROD_j p(y_j | y_0..j-1) where y_0..j-1 denotes the first j
-bits of y, and y_j is the next bit.  Compression depends almost entirely
-on the ability to predict the next bit accurately.
-
-
-MODEL MIXING
-
-paq8px uses a neural network to combine a large number of models.  The
-i'th model independently predicts
-p1_i = p(y_j = 1 | y_0..j-1), p0_i = 1 - p1_i.
-The network computes the next bit probabilty
-
-  p1 = squash(SUM_i w_i t_i), p0 = 1 - p1                        (1)
-
-where t_i = stretch(p1_i) is the i'th input, p1_i is the prediction of
-the i'th model, p1 is the output prediction, stretch(p) = ln(p/(1-p)),
-and squash(s) = 1/(1+exp(-s)).  Note that squash() and stretch() are
-inverses of each other.
-
-After bit y_j (0 or 1) is received, the network is trained:
-
-  w_i := w_i + eta t_i (y_j - p1)                                (2)
-
-where eta is an ad-hoc learning rate, t_i is the i'th input, (y_j - p1)
-is the prediction error for the j'th input but, and w_i is the i'th
-weight.  Note that this differs from back propagation:
-
-  w_i := w_i + eta t_i (y_j - p1) p0 p1                          (3)
-
-which is a gradient descent in weight space to minimize root mean square
-error.  Rather, the goal in compression is to minimize coding cost,
-which is -log(p0) if y = 1 or -log(p1) if y = 0.  Taking
-the partial derivative of cost with respect to w_i yields (2).
-
-
-MODELS
-
-Most models are context models.  A function of the context (last few
-bytes) is mapped by a lookup table or hash table to a state which depends
-on the bit history (prior sequence of 0 and 1 bits seen in this context).
-The bit history is then mapped to p1_i by a fixed or adaptive function.
-There are several types of bit history states:
-
-- Run Map. The state is (b,n) where b is the last bit seen (0 or 1) and
-  n is the number of consecutive times this value was seen.  The initial
-  state is (0,0).  The output is computed directly:
-
-    t_i = (2b - 1)K log(n + 1).
-
-  where K is ad-hoc, around 4 to 10.  When bit y_j is seen, the state
-  is updated:
-
-    (b,n) := (b,n+1) if y_j = b, else (y_j,1).
-
-- Stationary Map.  The state is p, initially 1/2.  The output is
-  t_i = stretch(p).  The state is updated at ad-hoc rate K (around 0.01):
-
-    p := p + K(y_j - p)
-
-- Nonstationary Map.  This is a compromise between a stationary map, which
-  assumes uniform statistics, and a run map, which adapts quickly by
-  discarding old statistics.  An 8 bit state represents (n0,n1,h), initially
-  (0,0,0) where:
-
-    n0 is the number of 0 bits seen "recently".
-    n1 is the number of 1 bits seen "recently".
-    n = n0 + n1.
-    h is the full bit history for 0 <= n <= 4,
-      the last bit seen (0 or 1) if 5 <= n <= 15,
-      0 for n >= 16.
-
-  The primaty output is t_i := stretch(sm(n0,n1,h)), where sm(.) is
-  a stationary map with K = 1/256, initialized to
-  sm(n0,n1,h) = (n1+(1/64))/(n+2/64).  Four additional inputs are also
-  be computed to improve compression slightly:
-
-    p1_i = sm(n0,n1,h)
-    p0_i = 1 - p1_i
-    t_i   := stretch(p_1)
-    t_i+1 := K1 (p1_i - p0_i)
-    t_i+2 := K2 stretch(p1) if n0 = 0, -K2 stretch(p1) if n1 = 0, else 0
-    t_i+3 := K3 (-p0_i if n1 = 0, p1_i if n0 = 0, else 0)
-    t_i+4 := K3 (-p0_i if n0 = 0, p1_i if n1 = 0, else 0)
-
-  where K1..K4 are ad-hoc constants.
-
-  h is updated as follows:
-    If n < 4, append y_j to h.
-    Else if n <= 16, set h := y_j.
-    Else h = 0.
-
-  The update rule is biased toward newer data in a way that allows
-  n0 or n1, but not both, to grow large by discarding counts of the
-  opposite bit.  Large counts are incremented probabilistically.
-  Specifically, when y_j = 0 then the update rule is:
-
-    n0 := n0 + 1, n < 29
-          n0 + 1 with probability 2^(27-n0)/2 else n0, 29 <= n0 < 41
-          n0, n = 41.
-    n1 := n1, n1 <= 5
-          round(8/3 lg n1), if n1 > 5
-
-  swapping (n0,n1) when y_j = 1.
-
-  Furthermore, to allow an 8 bit representation for (n0,n1,h), states
-  exceeding the following values of n0 or n1 are replaced with the
-  state with the closest ratio n0:n1 obtained by decrementing the
-  smaller count: (41,0,h), (40,1,h), (12,2,h), (5,3,h), (4,4,h),
-  (3,5,h), (2,12,h), (1,40,h), (0,41,h).  For example:
-  (12,2,1) 0-> (7,1,0) because there is no state (13,2,0).
-
-- Match Model.  The state is (c,b), initially (0,0), where c is 1 if
-  the context was previously seen, else 0, and b is the next bit in
-  this context.  The prediction is:
-
-    t_i := (2b - 1)Kc log(m + 1)
-
-  where m is the length of the context.  The update rule is c := 1,
-  b := y_j.  A match model can be implemented efficiently by storing
-  input in a buffer and storing pointers into the buffer into a hash
-  table indexed by context.  Then c is indicated by a hash table entry
-  and b can be retrieved from the buffer.
-
-
-CONTEXTS
-
-High compression is achieved by combining a large number of contexts.
-Most (not all) contexts start on a byte boundary and end on the bit
-immediately preceding the predicted bit.  The contexts below are
-modeled with both a run map and a nonstationary map unless indicated.
-
-- Order n.  The last n bytes, up to about 16.  For general purpose data.
-  Most of the compression occurs here for orders up to about 6.
-  An order 0 context includes only the 0-7 bits of the partially coded
-  byte and the number of these bits (255 possible values).
-
-- Sparse.  Usually 1 or 2 of the last 8 bytes preceding the byte containing
-  the predicted bit, e.g (2), (3),..., (8), (1,3), (1,4), (1,5), (1,6),
-  (2,3), (2,4), (3,6), (4,8).  The ordinary order 1 and 2 context, (1)
-  or (1,2) are included above.  Useful for binary data.
-
-- Text.  Contexts consists of whole words (a-z, converted to lower case
-  and skipping other values).  Contexts may be sparse, e.g (0,2) meaning
-  the current (partially coded) word and the second word preceding the
-  current one.  Useful contexts are (0), (0,1), (0,1,2), (0,2), (0,3),
-  (0,4).  The preceding byte may or may not be included as context in the
-  current word.
-
-- Formatted text.  The column number (determined by the position of
-  the last linefeed) is combined with other contexts: the charater to
-  the left and the character above it.
-
-- Fixed record length.  The record length is determined by searching for
-  byte sequences with a uniform stride length.  Once this is found, then
-  the record length is combined with the context of the bytes immediately
-  preceding it and the corresponding byte locations in the previous
-  one or two records (as with formatted text).
-
-- Context gap.  The distance to the previous occurrence of the order 1
-  or order 2 context is combined with other low order (1-2) contexts.
-
-- FAX.  For 2-level bitmapped images.  Contexts are the surrounding
-  pixels already seen.  Image width is assumed to be 1728 bits (as
-  in calgary/pic).
-
-- Image.  For uncompressed 24-bit color BMP, TIFF and TGA images.  Contexts
-  are the high order bits of the surrounding pixels and linear
-  combinations of those pixels, including other color planes.  The
-  image width is detected from the file header.  When an image is
-  detected, other models are turned off to improve speed.
-
-- JPEG.  Files are further compressed by partially uncompressing back
-  to the DCT coefficients to provide context for the next Huffman code.
-  Only baseline DCT-Huffman coded files are modeled.  (This ia about
-  90% of images, the others are usually progresssive coded).  JPEG images
-  embedded in other files (quite common) are detected by headers.  The
-  baseline JPEG coding process is:
-  - Convert to grayscale and 2 chroma colorspace.
-  - Sometimes downsample the chroma images 2:1 or 4:1 in X and/or Y.
-  - Divide each of the 3 images into 8x8 blocks.
-  - Convert using 2-D discrete cosine transform (DCT) to 64 12-bit signed
-    coefficients.
-  - Quantize the coefficients by integer division (lossy).
-  - Split the image into horizontal slices coded independently, separated
-    by restart codes.
-  - Scan each block starting with the DC (0,0) coefficient in zigzag order
-    to the (7,7) coefficient, interleaving the 3 color components in
-    order to scan the whole image left to right starting at the top.
-  - Subtract the previous DC component from the current in each color.
-  - Code the coefficients using RS codes, where R is a run of R zeros (0-15)
-    and S indicates 0-11 bits of a signed value to follow.  (There is a
-    special RS code (EOB) to indicate the rest of the 64 coefficients are 0).
-  - Huffman code the RS symbol, followed by S literal bits.
-  The most useful contexts are the current partially coded Huffman code
-  (including S following bits) combined with the coefficient position
-  (0-63), color (0-2), and last few RS codes.
-
-- Match.  When a context match of 400 bytes or longer is detected,
-  the next bit of the match is predicted and other models are turned
-  off to improve speed.
-
-- Exe.  When a x86 file (.exe, .obj, .dll) is detected, sparse contexts
-  with gaps of 1-12 selecting only the prefix, opcode, and the bits
-  of the modR/M byte that are relevant to parsing are selected.
-  This model is turned off otherwise.
-
-- Indirect.  The history of the last 1-3 bytes in the context of the
-  last 1-2 bytes is combined with this 1-2 byte context.
-
-- DMC. A bitwise n-th order context is built from a state machine using
-  DMC, described in http://plg.uwaterloo.ca/~ftp/dmc/dmc.c
-  The effect is to extend a single context, one bit at a time and predict
-  the next bit based on the history in this context.  The model here differs
-  in that two predictors are used.  One is a pair of counts as in the original
-  DMC.  The second predictor is a bit history state mapped adaptively to
-  a probability as as in a Nonstationary Map.
-
-ARCHITECTURE
-
-The context models are mixed by several of several hundred neural networks
-selected by a low-order context.  The outputs of these networks are
-combined using a second neural network, then fed through several stages of
-adaptive probability maps (APM) before arithmetic coding.
-
-For images, only one neural network is used and its context is fixed.
-
-An APM is a stationary map combining a context and an input probability.
-The input probability is stretched and divided into 32 segments to
-combine with other contexts.  The output is interpolated between two
-adjacent quantized values of stretch(p1).  There are 2 APM stages in series:
-
-  p1 := (p1 + 3 APM(order 0, p1)) / 4.
-  p1 := (APM(order 1, p1) + 2 APM(order 2, p1) + APM(order 3, p1)) / 4.
-
-PREPROCESSING
-
-paq8px uses preprocessing transforms on certain data types to improve
-compression.  To improve reliability, the decoding transform is
-tested during compression to ensure that the input file can be
-restored.  If the decoder output is not identical to the input file
-due to a bug, then the transform is abandoned and the data is compressed
-without a transform so that it will still decompress correctly.
-
-The input is split into blocks with the format <type> <decoded size> <data>
-where <type> is 1 byte (0 = no transform), <decoded size> is the size
-of the data after decoding, which may be different than the size of <data>.
-Blocks do not span file boundaries, and have a maximum size of 4MB to
-2GB depending on compression level.  Large files are split into blocks
-of this size.  The preprocessor has 3 parts:
-
-- Detector.  Splits the input into smaller blocks depending on data type.
-
-- Coder.  Input is a block to be compressed.  Output is a temporary
-  file.  The coder determines whether a transform is to be applied
-  based on file type, and if so, which one.  A coder may use lots
-  of resources (memory, time) and make multiple passes through the
-  input file.  The file type is stored (as one byte) during compression.
-
-- Decoder.  Performs the inverse transform of the coder.  It uses few
-  resorces (fast, low memory) and runs in a single pass (stream oriented).
-  It takes input either from a file or the arithmetic decoder.  Each call
-  to the decoder returns a single decoded byte.
-
-The following transforms are used:
-
-- EXE:  CALL (0xE8) and JMP (0xE9) address operands are converted from
-  relative to absolute address.  The transform is to replace the sequence
-  E8/E9 xx xx xx 00/FF by adding file offset modulo 2^25 (signed range,
-  little-endian format).  Data to transform is identified by trying the
-  transform and applying a crude compression test: testing whether the
-  byte following the E8/E8 (LSB of the address) occurred more recently
-  in the transformed data than the original and within 4KB 4 times in
-  a row.  The block ends when this does not happen for 4KB.
-
-- JPEG: detected by SOI and SOF and ending with EOI or any nondecodable
-  data.  No transform is applied.  The purpose is to separate images
-  embedded in execuables to block the EXE transform, and for a future
-  place to insert a transform.
-
-
-IMPLEMENTATION
-
-Hash tables are designed to minimize cache misses, which consume most
-of the CPU time.
-
-Most of the memory is used by the nonstationary context models.
-Contexts are represented by 32 bits, possibly a hash.  These are
-mapped to a bit history, represented by 1 byte.  The hash table is
-organized into 64-byte buckets on cache line boundaries.  Each bucket
-contains 7 x 7 bit histories, 7 16-bit checksums, and a 2 element LRU
-queue packed into one byte.  Each 7 byte element represents 7 histories
-for a context ending on a 3-bit boundary plus 0-2 more bits.  One
-element (for bits 0-1, which have 4 unused bytes) also contains a run model
-consisting of the last byte seen and a count (as 1 byte each).
-
-Run models use 4 byte hash elements consisting of a 2 byte checksum, a
-repeat count (0-255) and the byte value.  The count also serves as
-a priority.
-
-Stationary models are most appropriate for small contexts, so the
-context is used as a direct table lookup without hashing.
-
-The match model maintains a pointer to the last match until a mismatching
-bit is found.  At the start of the next byte, the hash table is referenced
-to find another match.  The hash table of pointers is updated after each
-whole byte.  There is no checksum.  Collisions are detected by comparing
-the current and matched context in a rotating buffer.
-
-The inner loops of the neural network prediction (1) and training (2)
-algorithms are implemented in MMX assembler, which computes 4 elements
-at a time.  Using assembler is 8 times faster than C++ for this code
-and 1/3 faster overall.  (However I found that SSE2 code on an AMD-64,
-which computes 8 elements at a time, is not any faster).
-
-
-DIFFERENCES FROM PAQ7
-
-An .exe model and filter are added.  Context maps are improved using 16-bit
-checksums to reduce collisions.  The state table uses probabilistic updates
-for large counts, more states that remember the last bit, and decreased
-discounting of the opposite count.  It is implemented as a fixed table.
-There are also many minor changes.
-
-DIFFERENCES FROM PAQ8A
-
-The user interface supports directory compression and drag and drop.
-The preprocessor segments the input into blocks and uses more robust
-EXE detection.  An indirect context model was added.  There is no
-dictionary preprocesor like PAQ8B/C/D/E.
-
-DIFFERENCES FROM PAQ8F
-
-Different models, usually from paq8hp*. Also changed rate from 8 to 7. A bug
-in Array was fixed that caused the program to silently crash upon exit.
-
-DIFFERENCES FROM PAQ8J
-
-1) Slightly improved sparse model.
-2) Added new family of sparse contexts. Each byte mapped to 3-bit value, where
-different values corresponds to different byte classes. For example, input
-byte 0x00 transformed into 0, all bytes that less then 16 -- into 5, all
-punctuation marks (ispunct(c)!=0) -- into 2 etc. Then this flags from 11
-previous bytes combined into 32-bit pseudo-context.
-
-All this improvements gives only 62 byte on BOOK1, but on binaries archive size
-reduced on 1-2%.
-
-DIFFERENCES FROM PAQ8JA
-
-Introduced distance model. Distance model uses distance to last occurence
-of some anchor char (0x00, space, newline, 0xff), combined with previous
-charactes as context. This slightly improves compression of files with
-variable-width record data.
-
-DIFFERENCES FROM PAQ8JB
-
-Restored recordModel(), broken in paq8hp*. Slightly tuned indirectModel().
-
-DIFFERENCES FROM PAQ8JC
-
-Changed the APMs in the Predictor. Up to a 0.2% improvement for some files.
-
-DIFFERENCES FROM PAQ8JD
-
-Added DMCModel.  Removed some redundant models from SparseModel and other
-minor tuneups.  Changes introduced in PAQ8K were not carried over.
-
-PAQ8L v.2
-
-Changed Mixer::p() to p() to fix a compiler error in Linux
-(patched by Indrek Kruusa, Apr. 15, 2007).
-
-DIFFERENCES FROM PAQ8L, PAQ8M
-
-Modified JPEG model by Jan Ondrus (paq8fthis2).  The new model improves
-compression by using decoded pixel values of current and adjacent blocks
-as context.  PAQ8M was an earlier version of the new JPEG model
-(from paq8fthis).
-
-DIFFERENCES FROM PAQ8N
-
-Improved bmp model. Slightly faster.
-
-DIFFERENCES FROM PAQ8O
-
-Modified JPEG model by Jan Ondrus (paq8fthis4).
-Added PGM (grayscale image) model form PAQ8I.
-Added grayscale BMP model to PGM model.
-Ver. 2 can be compiled using either old or new "for" loop scoping rules.
-Added APM and StateMap from LPAQ1
-Code optimizations from Enrico Zeidler
-Detection of BMP 4,8,24 bit and PGM 8 bit images before compress
-On non BMP,PGM,JPEG data mem is lower
-Fixed bug in BMP 8-bit detection in other files like .exe
-15. oct 2007
-Updates JPEG model by Jan Ondrus
-PGM detection bug fix
-22. oct 2007
-improved JPEG model by Jan Ondrus
-16. feb 2008
-fixed bmp detection bug
-added .rgb file support (uncompressed grayscale)
-
-DIFFERENCES FROM PAQ8O9
-
-Added wav Model. Slightly improved bmp model.
-
-DIFFERENCES FROM PAQ8P
-
-Added nestModel from paq8p3
-Modified wordModel from paq8p3
-Modified .pbm, .pgm, .ppm, .bmp, .rgb detection (from paq8p3)
-Modified WAV model (from paq8p_)
-Modified JPEG model (from paq8p2)
-Added im1bitModel (1-bit) (from paq8p3)
-Added compression of PPM, PBM images (from paq8p3)
-Removed pic model
-Modified EXE transformation (e8/e9)
-Changed image and audio data handling (separated in blocks)
-Added compression of (8-bit, 24-bit) TGA image data
-Improved TIFF image detection
-Added zlib stream recompression
-Added base64 transform (from paq8pxd)
-Modified im8bitModel (8-bit) (from paq8pxd)
-Added gif recompression
+/*
+  PAQ8PX file compressor/archiver
+  see README for information
+  see DOC for technical details
+  see CHANGELOG for version history
 */
-
 
 //////////////////////// Versioning ////////////////////////////////////////
 
-//Change the following values on a new build if applicable
-#define PROGNAME     "paq8px"  // Change this if you make a branch
-#define PROGVERSION  "141fix2"
+#define PROGNAME     "paq8px"
+#define PROGVERSION  "141fix4"  //update version here before publishing your changes
 #define PROGYEAR     "2018"
 
 
@@ -666,7 +75,7 @@ Added gif recompression
 #endif
 
 // Platform-independent includes
-#include <sys/stat.h> //stat(), mkdir(), stat()
+#include <sys/stat.h> //stat(), mkdir()
 #include <math.h>     //floor(), sqrt()
 #include <stdexcept>  //std::exception
 
@@ -780,11 +189,10 @@ int simd_detect() {
 //////////////////////// Type definitions /////////////////////////////////////////
 
 // shortcuts for 8, 16, 32 bit integer types
-typedef unsigned char      U8;
-typedef unsigned short     U16;
-typedef unsigned int       U32;
-typedef unsigned long long U64;
-typedef signed char        int8_t;
+typedef uint8_t  U8;
+typedef uint16_t U16;
+typedef uint32_t U32;
+typedef uint64_t U64;
 
 //////////////////////// Helper functions /////////////////////////////////////////
 
@@ -3110,6 +2518,11 @@ public:
     size_t len=strlen(Prefix);
     return (Length()>len && memcmp(&Letters[Start], Prefix, len)==0);
   }
+  void print() const {
+    for(int r=Start;r<=End;r++)
+      printf("%c",(char)Letters[r]);
+    printf("\n");
+  }
 };
 
 class Segment {
@@ -3153,6 +2566,7 @@ public:
     German,
     Count
   };
+  virtual ~Language() {};
   virtual bool IsAbbreviation(Word *W) = 0;
 };
 
@@ -3234,6 +2648,7 @@ protected:
     return (W->Start!=W->End && Rn<=W->Length()-strlen(Suffix));
   }
 public:
+  virtual ~Stemmer() {};
   virtual bool IsVowel(const char c) = 0;
   virtual void Hash(Word *W) = 0;
   virtual bool Stem(Word *W) = 0;
@@ -3358,15 +2773,15 @@ private:
   };
   static const int NUM_EXCEPTION_REGION1 = 3;
   const char *ExceptionsRegion1[NUM_EXCEPTION_REGION1]={"gener","arsen","commun"};
-  static const int NUM_EXCEPTIONS1 = 18;
+  static const int NUM_EXCEPTIONS1 = 19;
   const char *(Exceptions1[NUM_EXCEPTIONS1])[2]={
     {"skis", "ski"},
     {"skies", "sky"},
     {"dying", "die"},
     {"lying", "lie"},
     {"tying", "tie"},
-    {"idly", "idle"},
-    {"gently", "gentle"},
+    {"idly", "idl"},
+    {"gently", "gentl"},
     {"ugly", "ugli"},
     {"early", "earli"},
     {"only", "onli"},
@@ -3377,11 +2792,12 @@ private:
     {"atlas", "atlas"},
     {"cosmos", "cosmos"},
     {"bias", "bias"},
-    {"andes", "andes"}
+    {"andes", "andes"},
+    {"texas", "texas"}
   };
   const U32 TypesExceptions1[NUM_EXCEPTIONS1]={
     English::Noun|English::Plural,
-    English::Plural,
+    English::Noun|English::Plural,
     English::PresentParticiple,
     English::PresentParticiple,
     English::PresentParticiple,
@@ -3397,7 +2813,8 @@ private:
     English::Noun,
     English::Noun,
     English::Noun,
-    0
+    English::Noun|English::Plural,
+    English::Noun
   };
   static const int NUM_EXCEPTIONS2 = 8;
   const char *Exceptions2[NUM_EXCEPTIONS2]={"inning","outing","canning","herring","earring","proceed","exceed","succeed"};
@@ -3439,10 +2856,22 @@ private:
     }
     return false;
   }
-  bool TrimStartingApostrophe(Word *W) {
-    bool r=(W->Start!=W->End && (*W)[0]=='\'');
-    W->Start+=(U8)r;
-    return r;
+  bool TrimApostrophes(Word *W) {
+    bool result=false;
+    //trim all apostrophes from the beginning
+    int cnt=0;
+    while(W->Start!=W->End && (*W)[0]=='\'') {
+      result=true;
+      W->Start++;
+      cnt++;
+    }
+    //trim the same number of apostrophes from the end (if there are)
+    while(W->Start!=W->End && (*W)(0)=='\'') {
+      if(cnt==0)break;
+      W->End--;
+      cnt--;
+    }
+    return result;
   }
   void MarkYsAsConsonants(Word *W) {
     if ((*W)[0]=='y')
@@ -3530,6 +2959,8 @@ private:
     }
     return (W->Type&English::AdjectiveSuperlative)>0;
   }
+  //Search for the longest among the suffixes, 's' or 's or ' and remove if found.
+  //Exaples: Children’s toys / Vice presidents' duties
   bool Step0(Word *W) {
     for (int i=0; i<NUM_SUFFIXES_STEP0; i++) {
       if (W->EndsWith(SuffixesStep0[i])) {
@@ -3540,19 +2971,29 @@ private:
     }
     return false;
   }
+
+  //Search for the longest among the following suffixes, and perform the action indicated.
   bool Step1a(Word *W) {
+
+    //sses -> replace by ss
     if (W->EndsWith("sses")) {
       W->End-=2;
       W->Type|=English::Plural;
       return true;
     }
+
+    //ied+ ies* -> replace by i if preceded by more than one letter, otherwise by ie (so ties -> tie, cries -> cri) 
     if (W->EndsWith("ied") || W->EndsWith("ies")) {
-      W->Type|=((*W)(0)=='d')?English::PastTense:English::Plural;
-      W->End-=1+(W->Length()>4);
+      W->Type |= ((*W)(0)=='d') ? English::PastTense : English::Plural;
+      W->End-= W->Length()>4 ? 2 : 1;
       return true;
     }
+
+    //us+ ss -> do nothing
     if (W->EndsWith("us") || W->EndsWith("ss"))
       return false;
+
+    //s -> delete if the preceding word part contains a vowel not immediately before the s (so gas and this retain the s, gaps and kiwis lose it) 
     if ((*W)(0)=='s' && W->Length()>2) {
       for (int i=W->Start;i<=W->End-2;i++) {
         if (IsVowel(W->Letters[i])) {
@@ -3562,34 +3003,37 @@ private:
         }
       }
     }
+
     if (W->EndsWith("n't") && W->Length()>4) {
       switch ((*W)(3)) {
         case 'a': {
           if ((*W)(4)=='c')
-            W->End-=2;
+            W->End-=2; // can't -> can
           else
-            W->ChangeSuffix("n't","ll");
+            W->ChangeSuffix("n't","ll"); // shan't -> shall
           break;
         }
-        case 'i': { W->ChangeSuffix("in't","m"); break; }
+        case 'i': { W->ChangeSuffix("in't","m"); break; } // ain't -> am
         case 'o': {
           if ((*W)(4)=='w')
-            W->ChangeSuffix("on't","ill");
+            W->ChangeSuffix("on't","ill"); // won't -> will
           else
-            W->End-=3;
+            W->End-=3; //don't -> do
           break;
         }
-        default: W->End-=3;
+        default: W->End-=3; // couldn't -> could, shouldn't -> should, needn't -> need, hasn't -> has
       }
-      W->Type|=English::Negation;
+      W->Type|=English::Negation;	
       return true;
     }
+
     if (W->EndsWith("hood") && W->Length()>7) {
-      W->End-=4;
+      W->End-=4;  //brotherhood -> brother
       return true;
     }
     return false;
   }
+  //Search for the longest among the following suffixes, and perform the action indicated. 
   bool Step1b(Word *W, const U32 R1) {
     for (int i=0; i<NUM_SUFFIXES_STEP1b; i++) {
       if (W->EndsWith(SuffixesStep1b[i])) {
@@ -3797,16 +3241,18 @@ private:
     }
     return res;
   }
+
+  //Search for the longest among the following suffixes, and, if found and in R2, perform the action indicated.
   bool Step4(Word *W, const U32 R2) {
     bool res=false;
     for (int i=0; i<NUM_SUFFIXES_STEP4; i++) {
       if (W->EndsWith(SuffixesStep4[i]) && SuffixInRn(W, R2, SuffixesStep4[i])) {
-        W->End-=U8(strlen(SuffixesStep4[i])-(i>17));
-        if (i!=10 || (*W)(0)!='m')
-          W->Type|=TypesStep4[i];
-        if (i==0 && W->EndsWith("nti")) {
-          W->End--;
-          res=true;
+        W->End-=U8(strlen(SuffixesStep4[i])-(i>17) /*sion, tion*/); // remove: al   ance   ence   er   ic   able   ible   ant   ement   ment   ent   ism   ate   iti   ous   ive   ize ; ion -> delete if preceded by s or t
+        if (!(i==10 /* ent */ && (*W)(0)=='m')) //exception: no TypesStep4 should be assigned for 'agreement'
+          W->Type|=TypesStep4[i]; 
+        if (i==0 && W->EndsWith("nti")) { 
+          W->End--; // ntial -> nt
+          res=true; // process ant+ial, ent+ial
           continue;
         }
         return true;
@@ -3814,20 +3260,22 @@ private:
     }
     return res;
   }
+
+  //Search for the the following suffixes, and, if found, perform the action indicated. 
   bool Step5(Word *W, const U32 R1, const U32 R2) {
     if ((*W)(0)=='e' && (*W)!="here") {
       if (SuffixInRn(W, R2, "e"))
-        W->End--;
+        W->End--; //e -> delete if in R2, or in R1 and not preceded by a short syllable 
       else if (SuffixInRn(W, R1, "e")) {
-        W->End--;
-        W->End+=!EndsInShortSyllable(W);
+        W->End--; //e -> delete if in R1 and not preceded by a short syllable 
+        W->End+=EndsInShortSyllable(W);
       }
       else
         return false;
       return true;
     }
     else if (W->Length()>1 && (*W)(0)=='l' && SuffixInRn(W, R2, "l") && (*W)(1)=='l') {
-      W->End--;
+      W->End--; //l -> delete if in R2 and preceded by l 
       return true;
     }
     return false;
@@ -3852,9 +3300,10 @@ public:
   bool Stem(Word *W) {
     if (W->Length()<2) {
       Hash(W);
+      //W->print(); //for debugging
       return false;
     }
-    bool res = TrimStartingApostrophe(W);
+    bool res = TrimApostrophes(W);
     res|=ProcessPrefixes(W);
     res|=ProcessSuperlatives(W);
     for (int i=0; i<NUM_EXCEPTIONS1; i++) {
@@ -3867,6 +3316,7 @@ public:
         Hash(W);
         W->Type|=TypesExceptions1[i];
         W->Language = Language::English;
+        //W->print(); //for debugging
         return (i<11);
       }
     }
@@ -3881,6 +3331,7 @@ public:
         Hash(W);
         W->Type|=TypesExceptions2[i];
         W->Language = Language::English;
+        //W->print(); //for debugging
         return res;
       }
     }
@@ -3906,6 +3357,7 @@ public:
     Hash(W);
     if (res)
       W->Language = Language::English;
+    //W->print(); //for debugging
     return res;
   }
 };
@@ -4607,7 +4059,15 @@ public:
     cSegment = &Segments(0);
     cSentence = &Sentences(0);
     cParagraph = &Paragraphs(0);
-    memset(&BytePos[0], 0, 256*sizeof(U32));
+    memset(&BytePos[0], 0, sizeof(BytePos));
+  }
+  ~TextModel() {
+    delete Stemmers[Language::English-1];
+    delete Stemmers[Language::French-1];
+    delete Stemmers[Language::German-1];
+    delete Languages[Language::English-1];
+    delete Languages[Language::French-1];
+    delete Languages[Language::German-1];
   }
   void Predict(Mixer& mixer, Buf& buffer, ModelStats *Stats = nullptr) {
     if (bpos==0) {
@@ -4640,9 +4100,9 @@ void TextModel::Update(Buf& buffer, ModelStats *Stats) {
   Info.lastLetter = min(0x1F, Info.lastLetter+1);
   Info.lastDigit  = min(0xFF, Info.lastDigit+1);
   Info.lastPunct  = min(0x3F, Info.lastPunct+1);
-  Info.lastNewLine++, Info.prevNewLine++, Info.lastNest++;
-  Info.spaceCount-=(Info.spaces>>31), Info.spaces<<=1;
-  Info.masks[0]<<=2, Info.masks[1]<<=2, Info.masks[2]<<=4, Info.masks[3]<<=3;
+  Info.lastNewLine++; Info.prevNewLine++; Info.lastNest++;
+  Info.spaceCount-=(Info.spaces>>31); Info.spaces<<=1;
+  Info.masks[0]<<=2; Info.masks[1]<<=2; Info.masks[2]<<=4; Info.masks[3]<<=3;
   pState = State;
 
   U8 c = buffer(1), pC=tolower(c);
@@ -10890,6 +10350,7 @@ int main(int argc, char** argv) {
         "    used as the archive filename.\n"
         "    When OUTPUTSPEC is a folder the archive file will be generated from\n"
         "    the input filename and will be created in the specified folder.\n"
+        "    If the archive file already exists it will be overwritten.\n"
         "\n"
         "    Examples:\n"
         "      " PROGNAME " -8 enwik8\n"


### PR DESCRIPTION
paq8px_v141fix3:
- Separated documentation from the source file (README, DOC, CHANGELOG)
- Updated (rewrote) README
- Gathered CHANGELOG information
- No code changes

paq8px_v141fix4:
- Cosmetic changes in the documents
  - README: is now UTF8 encoded for having non-ascii characters + small changes in the text
  - DOC: added warning that its content is partially obsolete
  - source file: a bit clearer header
- Small changes/fixes in Word, Language, TextModel and the English Stemmer classes
  - Added virtual destructors
  - Created a function to print the result of the stemmer (i.e. word stem) for debugging
  - Fixed 2 items in the Exceptions1 list (idle, gentle)
  - Fixed a bug in Step5 ( W->End+=!EndsInShortSyllable(W);  ->  W->End+=EndsInShortSyllable(W); )
  - Modified TrimStartingApostrophe() to trim more than 1 apostrophe both from the beginning and end in pairs
  - Commented some parts of the English Stemming routines
- Finally fixed the printf formatting warnings in Linux/GCC and Linux/Clang (changed typedef shortcuts for U8..U64)