### PR TITLE
paq8px_v156

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1153,30 +1153,36 @@ paq8px_v147
   - Compression is even better but a bit slower
   - Memory requirements are the same
 
+
 paq8px_v148
 2018.07.08
 - Mixer dot-product shifts are now configurable
 - SmallStationaryContextMap and StationaryMap can also use configurable prediction multipliers and divisors
+
 
 paq8px_v149
 2018.07.15
 - New match model with fast mode
 - Bug fixes for the ContextMaps and the 24/32bpp image model
 
+
 paq8px_v150
 2018.07.22
 - Improved the new MatchModel
 - New heuristic in the 24bpp color transform to detect RGB565 to RGB888 conversions
+
 
 paq8px_v151
 2018.07.25
 - Improved the 24/32bpp image model, reduced the memory usage
 - Slightly tweaked the JPEG model
 
+
 paq8px_v152
 2018.07.30
 - Modified the SmallStationaryContextMap to allow for variable bits-per-context
 - Improved the 24/32bpp image model, reduced the memory usage
+
 
 paq8px_v153
 2018.08.01
@@ -1185,14 +1191,39 @@ paq8px_v153
 - Modified text pre-training
 - On text blocks the exeModel is no longer used, and a different SSE stage is used
 
+
 paq8px_v154
 2018.08.05
 - Improved SSE stage for text blocks
+
 
 paq8px_v154a
 2018.08.06
 - Fix bug in EOL transform decode routine
 
+
 paq8px_v155
 2018.08.09
 - Improved SSE stage for 24/32bpp non-PNG images
+
+
+paq8px_v156
+2018.08.16
+- Small compression enhancement: in ContextMap 
+  - skipping mixing (add(0)) when state == 0  (unknown context).
+- Small compression enhancement: in matchModel 
+  - the default context was c0, now it is 0 (indicating "no match" or "mismatch")
+-- on mismatch, delta mode didn't switch immediately: fixed
+  - skipping mixing (add(0)) when state is empty (unknown context).
+  - tiny reduction in memory use
+- Small compression improvement: normalmodel to the front
+  - moved normalmodel in front of the special models improving compression of images and files containing mixed content
+- Minor fixes: in wordModel
+  - pC (previous character) was not converted to lovercase before use.
+  - added blocktype==TEXT_EOL condition where blocktype==TEXT was used.
+- Fixed: multiple file mode
+  - since v137 compression could degrade significantly due to a bug around block type/size detection
+  - it did not affect compression in single file mode
+- Cleanup: the global "f4" context was updated in the Predictor and was used both by wordModel and sparseModel. Moved all code to wordModel where it ought to be.
+- Cleanup: "normal model" is now a real model (not enbedded in ContextModel)
+- Miscellaneous cleanup in code/comments


### PR DESCRIPTION
- Small compression enhancement: in ContextMap 
  - skipping mixing (add(0)) when state == 0  (unknown context).
- Small compression enhancement: in matchModel 
  - the default context was c0, now it is 0 (indicating "no match" or "mismatch")
-- on mismatch, delta mode didn't switch immediately: fixed
  - skipping mixing (add(0)) when state is empty (unknown context).
  - tiny reduction in memory use
- Small compression improvement: normalmodel to the front
  - moved normalmodel in front of the special models improving compression of images and files containing mixed content
- Minor fixes: in wordModel
  - pC (previous character) was not converted to lovercase before use.
  - added blocktype==TEXT_EOL condition where blocktype==TEXT was used.
- Fixed: multiple file mode
  - since v137 compression could degrade significantly due to a bug around block type/size detection
  - it did not affect compression in single file mode
- Cleanup: the global "f4" context was updated in the Predictor and was used both by wordModel and sparseModel. Moved all code to wordModel where it ought to be.
- Cleanup: "normal model" is now a real model (not enbedded in ContextModel)
- Miscellaneous cleanup in code/comments