### PR TITLE
paq8px_v161

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1263,3 +1263,14 @@ paq8px_v160
 2018.08.22
 - Improved SSE stage for 8bpp color-indexed non-PNG images
 - Block size is now encoded with a variable-length integer coding scheme
+
+
+paq8px_v161
+2018.08.26
+- New SparseMatchModel
+- Slightly improved MatchModel
+- Tweaked mixer shifts for 8bpp images, 32bpp images and audio
+- Faster GIF transform (average 4.5x speedup)
+- Improved grayscale image detection routine
+- Fixed GIF grayscale detection, include processing of local color palettes
+- Fixed bug in number of total mixer inputs (present since v159)


### PR DESCRIPTION
- New SparseMatchModel
- Slightly improved MatchModel
- Tweaked mixer shifts for 8bpp images, 32bpp images and audio
- Faster GIF transform (average 4.5x speedup)
- Improved grayscale image detection routine
- Fixed GIF grayscale detection, include processing of local color palettes
- Fixed bug in number of total mixer inputs (present since v159)