### PR TITLE
Defines to allow compilation on ARM devices

### DIFF
--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -7,10 +7,10 @@
 
 #ifdef WINDOWS
 #include <intrin.h>
-#else
-
+#elif defined(__i386__) || defined(__x86_64)
 #include <immintrin.h>
-
+#else
+#include <arm_neon.h>
 #endif
 
 static inline auto clz(uint32_t value) -> uint32_t {

--- a/Ilog.cpp
+++ b/Ilog.cpp
@@ -1,4 +1,11 @@
 #include "Ilog.hpp"
+#if defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+#define vreinterpretq_m128_f32(x) \
+        (x)
+#define vreinterpretq_f32_m128(x) \
+        (x)
+#include <arm_neon.h>
+#endif
 
 auto Ilog::log(uint16_t x) const -> int { return static_cast<int>(t[x]); }
 
@@ -44,6 +51,10 @@ auto VLICost(uint64_t n) -> int {
 }
 
 auto rsqrt(const float x) -> float {
+#if defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+  float r = vgetq_lane_f32(vreinterpretq_f32_m128(vreinterpretq_m128_f32(vrsqrteq_f32(vreinterpretq_f32_m128(vdupq_n_f32(x))))),0); //NEON
+#else
   float r = _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); //SSE
+#endif
   return (0.5F * (r + 1.0F / (x * r)));
 }

--- a/Ilog.hpp
+++ b/Ilog.hpp
@@ -3,7 +3,11 @@
 
 #include "Array.hpp"
 #include "cstdint"
+#if defined(__i386__) || defined(__x86_64__)
 #include <xmmintrin.h>
+#elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+#include <arm_neon.h>
+#endif
 
 /**
  * ilog(x) = round(log2(x) * 16), 0 <= x < 64K

--- a/Mixer.hpp
+++ b/Mixer.hpp
@@ -104,9 +104,8 @@ static void trainSimdSse2(const short *const t, short *const w, int n, const int
 static auto dotProductSimdNone(const short *const t, const short *const w, int n) -> int {
   int sum = 0;
   while((n -= 2) >= 0 ) {
-    sum += ((t[n] * w[n]) + (t[n + 1] * w[n + 1])) >> 8U;
+    sum += (t[n] * w[n] + t[n + 1] * w[n + 1]) >> 8U;
   }
-  sum = sum >> 8U;
   return sum;
 }
 

--- a/OLS.hpp
+++ b/OLS.hpp
@@ -136,8 +136,9 @@ public:
     }
 
 #ifdef __GNUC__
-
+#ifdef __AVX2__
     __attribute__((target("avx2")))
+#endif
 #endif
     void updateAVX2(const T val) {
       F mul = 1.0 - lambda;

--- a/simd.hpp
+++ b/simd.hpp
@@ -6,19 +6,25 @@
 // Uncomment one or more of the following includes if you plan adding more SIMD dispatching
 //#include <mmintrin.h>  //MMX
 //#include <xmmintrin.h> //SSE
+#ifdef __SSE2__
 #include <emmintrin.h> //SSE2
+#endif
 //#include <pmmintrin.h> //SSE3
 //#include <tmmintrin.h> //SSSE3
 //#include <smmintrin.h> //SSE4.1
 //#include <nmmintrin.h> //SSE4.2
 //#include <ammintrin.h> //SSE4A
+#if defined(__AVX__) ||defined(__AVX2__)
 #include <immintrin.h> //AVX, AVX2
+#endif
 //#include <zmmintrin.h> //AVX512
 
 //define CPUID
 #if defined(__GNUC__)||defined(__clang__)
+#if !defined(__ARM_FEATURE_SIMD32)&&!defined(__ARM_NEON)
 #include <cpuid.h>
 #define cpuid(info, x) __cpuid_count(x, 0, (info)[0], (info)[1], (info)[2], (info)[3])
+#endif
 #elif defined(_MSC_VER)
 #include <intrin.h>
 #define cpuid(info, x) __cpuidex(info, x, 0)
@@ -58,6 +64,9 @@ static inline auto xgetbv(unsigned long ctr) -> unsigned long long {
  : AVX512 //TODO
 */
 static auto simdDetect() -> int {
+#if defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+  return 0;
+#else
   int cpuidResult[4] = {0, 0, 0, 0};
   cpuid(cpuidResult, 0); // call cpuid function 0 ("Get vendor ID and highest basic calling parameter")
   if( cpuidResult[0] == 0 ) {
@@ -107,6 +116,7 @@ static auto simdDetect() -> int {
   }
   //AVX2: OK
   return 9;
+#endif
 }
 
 #endif //PAQ8PX_SIMD_HPP


### PR DESCRIPTION
Since ARM processors don't have `immintrin.h`, I added some defines to check if we are compiling on x86 or ARM and replaced some functions if we are compiling under ARM. 

Tested on Ubuntu running on Termux on a Samsung Galaxy S9+. Also compiled it on Windows to make sure it ran.