### PR TITLE
Cleanup1

### DIFF
--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -9,7 +9,7 @@
 #include <intrin.h>
 #elif defined(__i386__) || defined(__x86_64)
 #include <immintrin.h>
-#else
+#elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
 #include <arm_neon.h>
 #endif
 

--- a/Ilog.cpp
+++ b/Ilog.cpp
@@ -1,7 +1,4 @@
 #include "Ilog.hpp"
-#if defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
-#include <arm_neon.h>
-#endif
 
 auto Ilog::log(uint16_t x) const -> int { return static_cast<int>(t[x]); }
 

--- a/Ilog.hpp
+++ b/Ilog.hpp
@@ -5,6 +5,8 @@
 #include "cstdint"
 #if defined(__i386__) || defined(__x86_64__)
 #include <xmmintrin.h>
+#elseif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+#include <arm_neon.h>
 #endif
 
 /**

--- a/Ilog.hpp
+++ b/Ilog.hpp
@@ -5,7 +5,7 @@
 #include "cstdint"
 #if defined(__i386__) || defined(__x86_64__)
 #include <xmmintrin.h>
-#elseif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+#elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
 #include <arm_neon.h>
 #endif
 

--- a/SimdMixer.hpp
+++ b/SimdMixer.hpp
@@ -19,10 +19,7 @@ private:
       if( simd == SIMD_AVX2 ) {
         return 32 / sizeof(short); // 256 bit (32 byte) data size
       }
-      if( simd == SIMD_SSE2 ) {
-        return 16 / sizeof(short); // 128 bit (16 byte) data size
-      }
-      if (simd == SIMD_NEON) {
+      if( simd == SIMD_SSE2 || simd == SIMD_NEON ) {
         return 16 / sizeof(short); // 128 bit (16 byte) data size
       }
       if( simd == SIMD_NONE ) {


### PR DESCRIPTION
## Bucket.hpp
Changed the `#else` to `#elif` to check if we are compiling on ARM. Previously it would assume it was if the `#if` check failed.

## Ilog.cpp / Ilog.hpp
Moved the ARM include from `Ilog.cpp` to `Ilog.hpp` to maintain the current standard.

## SimdMixer.hpp
Merged the SIMD_SSE2 and SIMD_NEON into one `if` statement, since both returns the same value.