### PR TITLE
v187: Ported Bucket to NEON and AVX2, and some misc stuff.

### DIFF
--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -72,6 +72,8 @@ static inline int32x4_t _mm_sad_epu8(int32x4_t a, int32x4_t b)
     return (int32x4_t) vsetq_lane_u16(r4, r, 4);
 }
 
+#endif
+
 static inline auto clz(uint32_t value) -> uint32_t {
   return __builtin_clz(value);
 }

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -11,6 +11,76 @@
 #include <immintrin.h>
 #elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
 #include <arm_neon.h>
+
+// Below functions taken and adapted from https://github.com/jratcliff63367/sse2neon/blob/master/SSE2NEON.h
+static inline int32x4_t _mm_srli_si128(a, imm) {
+  if ((imm) <= 0)
+    return a;
+  else if ((imm) > 15)
+    return vdupq_n_s32(0);
+  else
+    return vreinterpretq_s32_s8(vextq_s8(vreinterpretq_s8_s32(a), vdupq_n_s8(0), (imm)));
+}
+
+static inline int _mm_movemask_epi8(int32x4_t _a)
+{
+    uint8x16_t input = vreinterpretq_u8_m128i(_a);
+    static const int8_t __attribute__((aligned(16))) xr[8] = { -7, -6, -5, -4, -3, -2, -1, 0 };
+    uint8x8_t mask_and = vdup_n_u8(0x80);
+    int8x8_t mask_shift = vld1_s8(xr);
+
+    uint8x8_t lo = vget_low_u8(input);
+    uint8x8_t hi = vget_high_u8(input);
+
+    lo = vand_u8(lo, mask_and);
+    lo = vshl_u8(lo, mask_shift);
+
+    hi = vand_u8(hi, mask_and);
+    hi = vshl_u8(hi, mask_shift);
+
+    lo = vpadd_u8(lo, lo);
+    lo = vpadd_u8(lo, lo);
+    lo = vpadd_u8(lo, lo);
+
+    hi = vpadd_u8(hi, hi);
+    hi = vpadd_u8(hi, hi);
+    hi = vpadd_u8(hi, hi);
+
+  return ((hi[0] << 8) | (lo[0] & 0xFF));
+}
+
+// Below functions taken and adapted from https://github.com/DLTcollab/sse2neon/blob/master/sse2neon.h
+static inline int32x4_t _mm_set_epi8(signed char b15, signed char b14, signed char b13, signed char b12,
+    signed char b11, signed char b10, signed char b9, signed char b8,
+    signed char b7, signed char b6, signed char b5, signed char b4,
+    signed char b3, signed char b2, signed char b1, signed char b0)
+{
+    int8_t __attribute__((aligned(16)))
+        data[16] = { (int8_t)b0,  (int8_t)b1,  (int8_t)b2,  (int8_t)b3,
+                     (int8_t)b4,  (int8_t)b5,  (int8_t)b6,  (int8_t)b7,
+                     (int8_t)b8,  (int8_t)b9,  (int8_t)b10, (int8_t)b11,
+                     (int8_t)b12, (int8_t)b13, (int8_t)b14, (int8_t)b15 };
+    return (int32x4_t)vld1q_s8(data);
+}
+
+static inline int32x4_t _mm_sad_epu8(int32x4_t a, int32x4_t b)
+{
+    uint16x8_t t = vpaddlq_u8(vabdq_u8((uint8x16_t)a, (uint8x16_t)b));
+    uint16_t r0 = t[0] + t[1] + t[2] + t[3];
+    uint16_t r4 = t[4] + t[5] + t[6] + t[7];
+    uint16x8_t r = vsetq_lane_u16(r0, vdupq_n_u16(0), 0);
+    return (int32x4_t) vsetq_lane_u16(r4, r, 4);
+}
+
+static inline int _mm_movemask_epi8(int32x4_t a)
+{
+    uint8x16_t input = vreinterpretq_u8_s64(a);
+    uint16x8_t high_bits = vreinterpretq_u16_u8(vshrq_n_u8(input, 7));
+    uint32x4_t paired16 = vreinterpretq_u32_u16(vsraq_n_u16(high_bits, high_bits, 7));
+    uint64x2_t paired32 = vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
+    uint8x16_t paired64 = vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
+    return vgetq_lane_u8(paired64, 0) | ((int)vgetq_lane_u8(paired64, 8) << 8);
+}
 #endif
 
 static inline auto clz(uint32_t value) -> uint32_t {
@@ -88,6 +158,55 @@ public:
       mostRecentlyUsed = 0xF0U | idx;
       checksums[idx] = checksum;
       return static_cast<uint8_t *>(memset(&bitState[idx][0], 0, 7));
+#elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+      if (checksums[mostRecentlyUsed & 15U] == checksum) {
+          return &bitState[mostRecentlyUsed & 15U][0];
+      }
+      int worst = 0xFFFF;
+      int idx = 0;
+      const int32x4_t xmmChecksum = vreinterpretq_s32_s16(vdupq_n_s16(short(checksum))); //fill 8 ch values
+      // load 8 values, discard last one as only 7 are needed.
+      // reverse order and compare 7 checksums values to @ref checksum
+      // get mask is set get first index and return value
+      int32x4_t = vld1q_s32(reinterpret_cast<int32_t*>(&checksums[0])); //load 8 values (8th will be discarded)
+
+      tmp = vtbl_s32(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
+      tmp = vceqq_s16(vreinterpretq_s16_s32(tmp), vreinterpretq_s16_s32(xmmChecksum)); // compare ch values
+      tmp = vcombine_s8(vqmovn_s16(vreinterpretq_s16_s32(tmp)), vqmovn_s16(vreinterpretq_s16_s32(vdupq_n_s32(0)))); // pack result
+      uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
+      uint32_t a = 0;    // index into bitState or 7 if not found
+      if (t != 0u) {
+        a = (clz(t) - 1) & 7U;
+        mostRecentlyUsed = mostRecentlyUsed << 4U | a;
+        return &bitState[a][0];
+      }
+
+      int32x4_t lastL = vreinterpretq_s32_s8(vdupq_n_s8((mostRecentlyUsed & 15U)));
+      int32x4_t lastH = vreinterpretq_s32_s8(vdupq_n_s8((mostRecentlyUsed >> 4U)));
+      int32x4_t one1 = vreinterpretq_s32_s8(vdupq_n_s8(1));
+      int32x4_t vm = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
+
+      int32x4_t lastX = vcombine_s64(vget_low_s64(lastL), vget_low_s64(lastH)); // mostRecentlyUsed&15 mostRecentlyUsed>>4
+      int32x4_t eq0 = vreinterpretq_s64_u8(vceqq_s8(vreinterpretq_s8_s64(lastX), vreinterpretq_s8_s64(vm))); // compare values
+
+      eq0 = vorrq_s32(eq0, _mm_srli_si128(eq0, 8));    // or low values with high
+
+      lastX = vandq_s32(one1, eq0); //set to 1 if eq
+      int32x4_t sum1 = _mm_sad_epu8(lastX, vdupq_n_s32(0)); // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
+      const uint32_t pCount = vgetq_lane_s32(sum1, 0); // population count
+      uint32_t t0 = (~_mm_movemask_epi8(eq0));
+      for (int i = pCount; i < 7; ++i) {
+        int bitt = ctz(t0);     // get index
+        t0 &= ~(1 << bitt); // clear bit set and test again
+        int pri = bitState[bitt][0];
+        if (pri < worst) {
+          worst = pri;
+          idx = bitt;
+        }
+      }
+      mostRecentlyUsed = 0xF0U | idx;
+      checksums[idx] = checksum;
+      return static_cast<uint8_t*>(memset(&bitState[idx][0], 0, 7));
 #else
       if( checksums[mostRecentlyUsed & 15U] == checksum ) {
         return &bitState[mostRecentlyUsed & 15U][0];

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -200,7 +200,7 @@ public:
       int32x4_t one1 = vreinterpretq_s32_s8(vdupq_n_s8(1));
       int32x4_t vm = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
 
-      int32x4_t lastX = vcombine_s64(vget_low_s64(lastL), vget_low_s64(lastH)); // mostRecentlyUsed&15 mostRecentlyUsed>>4
+      int32x4_t lastX = vcombine_s64(vget_low_s64(vreinterpretq_s64_s32(lastL)), vget_low_s64(vreinterpretq_s64_s32(lastH))); // mostRecentlyUsed&15 mostRecentlyUsed>>4
       int32x4_t eq0 = vreinterpretq_s64_u8(vceqq_s8(vreinterpretq_s8_s32(lastX), vreinterpretq_s8_s32(vm))); // compare values
 
       eq0 = vorrq_s32(eq0, _mm_srli_si128(eq0, 8));    // or low values with high

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -74,8 +74,8 @@ static inline int32x4_t _mm_sad_epu8(int32x4_t a, int32x4_t b)
 
 static inline int32x4_t _mm_shuffle_epi8(int32x4_t a, int32x4_t b)
 {
-    int8x16_t tbl = vreinterpretq_s8_s64(a);   // input a
-    uint8x16_t idx = vreinterpretq_u8_s64(b);  // input b
+    int8x16_t tbl = vreinterpretq_s8_s32(a);   // input a
+    uint8x16_t idx = vreinterpretq_u8_s32(b);  // input b
     uint8x16_t idx_masked = vandq_u8(idx, vdupq_n_u8(0x8F));  // avoid using meaningless bits
 #if defined(__aarch64__)
     return vreinterpretq_s64_s8(vqtbl1q_s8(tbl, idx_masked)); //function only exist on ARMv8
@@ -201,7 +201,7 @@ public:
       int32x4_t vm = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
 
       int32x4_t lastX = vcombine_s64(vget_low_s64(lastL), vget_low_s64(lastH)); // mostRecentlyUsed&15 mostRecentlyUsed>>4
-      int32x4_t eq0 = vreinterpretq_s64_u8(vceqq_s8(vreinterpretq_s8_s64(lastX), vreinterpretq_s8_s64(vm))); // compare values
+      int32x4_t eq0 = vreinterpretq_s64_u8(vceqq_s8(vreinterpretq_s8_s32(lastX), vreinterpretq_s8_s32(vm))); // compare values
 
       eq0 = vorrq_s32(eq0, _mm_srli_si128(eq0, 8));    // or low values with high
 

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -71,7 +71,6 @@ static inline int32x4_t _mm_sad_epu8(int32x4_t a, int32x4_t b)
     uint16x8_t r = vsetq_lane_u16(r0, vdupq_n_u16(0), 0);
     return (int32x4_t) vsetq_lane_u16(r4, r, 4);
 }
-
 #endif
 
 static inline auto clz(uint32_t value) -> uint32_t {
@@ -159,7 +158,7 @@ public:
       // load 8 values, discard last one as only 7 are needed.
       // reverse order and compare 7 checksums values to @ref checksum
       // get mask is set get first index and return value
-      int32x4_t = vld1q_s32(reinterpret_cast<int32_t*>(&checksums[0])); //load 8 values (8th will be discarded)
+      int32x4_t tmp = vld1q_s32(reinterpret_cast<int32_t*>(&checksums[0])); //load 8 values (8th will be discarded)
 
       tmp = vtbl_s32(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
       tmp = vceqq_s16(vreinterpretq_s16_s32(tmp), vreinterpretq_s16_s32(xmmChecksum)); // compare ch values

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include "Shared.hpp"
 #include "utils.hpp"
 
 #ifdef WINDOWS
@@ -118,87 +119,126 @@ public:
      * @param checksum
      * @return
      */
-    inline auto find(const uint16_t checksum) -> uint8_t * {
-#if defined(__SSSE3__)
-      if( checksums[mostRecentlyUsed & 15U] == checksum ) {
+
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__AVX2__)
+    __attribute__((target("avx2")))
+#endif
+    inline auto findAvx2(const uint16_t checksum) -> uint8_t* {
+#ifndef __AVX2__
+      return 0;
+#else
+      if (checksums[mostRecentlyUsed & 15U] == checksum) {
         return &bitState[mostRecentlyUsed & 15U][0];
       }
       int worst = 0xFFFF;
       int idx = 0;
-#if defined(__AVX2__)
       const __m256i xmmChecksum = _mm256_set1_epi16(short(checksum)); //fill 8 ch values
-     //// load 8 values, discard last one as only 7 are needed.
-     //// reverse order and compare 7 checksums values to @ref checksum
-     //// get mask is set get first index and return value
+      /// load 8 values, discard last one as only 7 are needed.
+      /// reverse order and compare 7 checksums values to @ref checksum
+      /// get mask is set get first index and return value
       __m256i tmp = _mm256_load_si256(reinterpret_cast<__m256i*>(&checksums[0]));
       tmp = _mm256_shuffle_epi8(tmp, _mm256_setr_epi8(30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
       tmp = _mm256_cmpeq_epi16(tmp, xmmChecksum); // compare ch values
       tmp = _mm256_packs_epi16(tmp, _mm256_setzero_si256()); // pack result
       _mm256_zeroupper();
       uint32_t t = (_mm256_movemask_epi8((tmp))) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
-#else
-      const __m128i xmmChecksum = _mm_set1_epi16(short(checksum)); //fill 8 ch values
-      // load 8 values, discard last one as only 7 are needed.
-      // reverse order and compare 7 checksums values to @ref checksum
-      // get mask is set get first index and return value
-      __m128i tmp = _mm_load_si128(reinterpret_cast<__m128i *>(&checksums[0])); //load 8 values (8th will be discarded)
-
-      tmp = _mm_shuffle_epi8(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
-      tmp = _mm_cmpeq_epi16(tmp, xmmChecksum); // compare ch values
-      tmp = _mm_packs_epi16(tmp, _mm_setzero_si128()); // pack result
-      uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
-#endif
       uint32_t a = 0;    // index into bitState or 7 if not found
-      if( t != 0u ) {
+      if (t != 0u) {
         a = (clz(t) - 1) & 7U;
-        mostRecentlyUsed = mostRecentlyUsed << 4U | a;
-        return &bitState[a][0];
+          mostRecentlyUsed = mostRecentlyUsed << 4U | a;
+          return &bitState[a][0];
       }
-#if defined(__AVX2__)
       __m256i lastL = _mm256_set1_epi8((mostRecentlyUsed & 15U));
       __m256i lastH = _mm256_set1_epi8((mostRecentlyUsed >> 4U));
       __m256i one1 = _mm256_set1_epi8(1);
       __m256i vm = _mm256_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
-
+      
       __m256i lastX = _mm256_unpacklo_epi64(lastL, lastH); // mostRecentlyUsed&15 mostRecentlyUsed>>4
       __m256i eq0 = _mm256_cmpeq_epi8(lastX, vm); // compare values
 
       eq0 = _mm256_or_si256(eq0, _mm256_srli_si256(eq0, 8));    // or low values with high
-
+      
       lastX = _mm256_and_si256(one1, eq0);                //set to 1 if eq
       __m256i sum1 = _mm256_sad_epu8(lastX, _mm256_setzero_si256());        // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
       const uint32_t pCount = _mm_cvtsi128_si32(_mm256_castsi256_si128(sum1)); // population count
       _mm256_zeroupper();
       uint32_t t0 = (~_mm256_movemask_epi8(eq0));
-#else
-      __m128i lastL = _mm_set1_epi8((mostRecentlyUsed & 15U));
-      __m128i lastH = _mm_set1_epi8((mostRecentlyUsed >> 4U));
-      __m128i one1 = _mm_set1_epi8(1);
-      __m128i vm = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
-
-      __m128i lastX = _mm_unpacklo_epi64(lastL, lastH); // mostRecentlyUsed&15 mostRecentlyUsed>>4
-      __m128i eq0 = _mm_cmpeq_epi8(lastX, vm); // compare values
-
-      eq0 = _mm_or_si128(eq0, _mm_srli_si128 (eq0, 8));    // or low values with high
-
-      lastX = _mm_and_si128(one1, eq0);                //set to 1 if eq
-      __m128i sum1 = _mm_sad_epu8(lastX, _mm_setzero_si128());        // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
-      const uint32_t pCount = _mm_cvtsi128_si32(sum1); // population count
-      uint32_t t0 = (~_mm_movemask_epi8(eq0));
-#endif
-      for( int i = pCount; i < 7; ++i ) {
+      for (int i = pCount; i < 7; ++i) {
         int bitt = ctz(t0);     // get index
         t0 &= ~(1 << bitt); // clear bit set and test again
         int pri = bitState[bitt][0];
-        if( pri < worst ) {
+        if (pri < worst) {
           worst = pri;
           idx = bitt;
         }
       }
       mostRecentlyUsed = 0xF0U | idx;
       checksums[idx] = checksum;
-      return static_cast<uint8_t *>(memset(&bitState[idx][0], 0, 7));
-#elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
+      return static_cast<uint8_t*>(memset(&bitState[idx][0], 0, 7));
+#endif
+    }
+
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__SSSE3__)
+    __attribute__((target("ssse3")))
+#endif
+    inline auto findSsse3(const uint16_t checksum) -> uint8_t* {
+#ifndef __SSSE3__
+      return 0;
+#else
+      if (checksums[mostRecentlyUsed & 15U] == checksum) {
+        return &bitState[mostRecentlyUsed & 15U][0];
+      }
+      int worst = 0xFFFF;
+      int idx = 0;
+      const __m128i xmmChecksum = _mm_set1_epi16(short(checksum)); //fill 8 ch values
+      // load 8 values, discard last one as only 7 are needed.
+      // reverse order and compare 7 checksums values to @ref checksum
+      // get mask is set get first index and return value
+      __m128i tmp = _mm_load_si128(reinterpret_cast<__m128i*>(&checksums[0])); //load 8 values (8th will be discarded)
+
+      tmp = _mm_shuffle_epi8(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
+      tmp = _mm_cmpeq_epi16(tmp, xmmChecksum); // compare ch values
+      tmp = _mm_packs_epi16(tmp, _mm_setzero_si128()); // pack result
+      uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
+      uint32_t a = 0;    // index into bitState or 7 if not found
+      if (t != 0u) {
+        a = (clz(t) - 1) & 7U;
+        mostRecentlyUsed = mostRecentlyUsed << 4U | a;
+        return &bitState[a][0];
+      }
+      __m128i lastL = _mm_set1_epi8((mostRecentlyUsed & 15U));
+      __m128i lastH = _mm_set1_epi8((mostRecentlyUsed >> 4U));
+      __m128i one1 = _mm_set1_epi8(1);
+      __m128i vm = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
+      
+      __m128i lastX = _mm_unpacklo_epi64(lastL, lastH); // mostRecentlyUsed&15 mostRecentlyUsed>>4
+      __m128i eq0 = _mm_cmpeq_epi8(lastX, vm); // compare values
+
+      eq0 = _mm_or_si128(eq0, _mm_srli_si128(eq0, 8));    // or low values with high
+
+      lastX = _mm_and_si128(one1, eq0);                //set to 1 if eq
+      __m128i sum1 = _mm_sad_epu8(lastX, _mm_setzero_si128());        // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
+      const uint32_t pCount = _mm_cvtsi128_si32(sum1); // population count
+      uint32_t t0 = (~_mm_movemask_epi8(eq0));
+      for (int i = pCount; i < 7; ++i) {
+        int bitt = ctz(t0);     // get index
+        t0 &= ~(1 << bitt); // clear bit set and test again
+        int pri = bitState[bitt][0];
+        if (pri < worst) {
+          worst = pri;
+          idx = bitt;
+        }
+      }
+      mostRecentlyUsed = 0xF0U | idx;
+      checksums[idx] = checksum;
+      return static_cast<uint8_t*>(memset(&bitState[idx][0], 0, 7));
+#endif
+    }
+
+    inline auto findNeon(const uint16_t checksum) -> uint8_t* {
+#if (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
+      return 0;
+#else
       if (checksums[mostRecentlyUsed & 15U] == checksum) {
           return &bitState[mostRecentlyUsed & 15U][0];
       }
@@ -247,7 +287,10 @@ public:
       mostRecentlyUsed = 0xF0U | idx;
       checksums[idx] = checksum;
       return static_cast<uint8_t*>(memset(&bitState[idx][0], 0, 7));
-#else
+#endif
+    }
+
+    inline auto findNone(const uint16_t checksum) -> uint8_t* {
       if( checksums[mostRecentlyUsed & 15U] == checksum ) {
         return &bitState[mostRecentlyUsed & 15U][0];
       }
@@ -265,7 +308,23 @@ public:
       mostRecentlyUsed = 0xF0U | idx;
       checksums[idx] = checksum;
       return (uint8_t *) memset(&bitState[idx][0], 0, 7);
-#endif
+    }
+
+    inline auto find(const uint16_t checksum, const SIMD chosenSimd) {
+      if ( chosenSimd == SIMD_NONE || chosenSimd == SIMD_SSE2 ) {
+        return findNone(checksum);
+      }
+      else if ( chosenSimd == SIMD_SSSE3 ) {
+        return findSsse3(checksum);
+      }
+      else if ( chosenSimd == SIMD_AVX2 ) {
+        return findAvx2(checksum);
+      }
+      else if ( chosenSimd == SIMD_NEON ) {
+        return findNeon(checksum);
+      }
+      assert(false);
+      return (uint8_t*) 0;
     }
 };
 

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -200,7 +200,7 @@ public:
       int32x4_t one1 = vreinterpretq_s32_s8(vdupq_n_s8(1));
       int32x4_t vm = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
 
-      int32x4_t lastX = vcombine_s64(vget_low_s64(vreinterpretq_s64_s32(lastL)), vget_low_s64(vreinterpretq_s64_s32(lastH))); // mostRecentlyUsed&15 mostRecentlyUsed>>4
+      int32x4_t lastX = vreinterpretq_s32_s64(vcombine_s64(vget_low_s64(vreinterpretq_s64_s32(lastL)), vget_low_s64(vreinterpretq_s64_s32(lastH)))); // mostRecentlyUsed&15 mostRecentlyUsed>>4
       int32x4_t eq0 = vreinterpretq_s32_u8(vceqq_s8(vreinterpretq_s8_s32(lastX), vreinterpretq_s8_s32(vm))); // compare values
 
       eq0 = vorrq_s32(eq0, _mm_srli_si128(eq0, 8));    // or low values with high

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -143,7 +143,7 @@ public:
       _mm256_zeroupper();
       uint32_t t = (_mm256_movemask_epi8((tmp))) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
       uint32_t a = 0;    // index into bitState or 7 if not found
-      if (t != 0u) {
+      if ( t != 0u ) {
         a = (clz(t) - 1) & 7U;
           mostRecentlyUsed = mostRecentlyUsed << 4U | a;
           return &bitState[a][0];
@@ -163,11 +163,11 @@ public:
       const uint32_t pCount = _mm_cvtsi128_si32(_mm256_castsi256_si128(sum1)); // population count
       _mm256_zeroupper();
       uint32_t t0 = (~_mm256_movemask_epi8(eq0));
-      for ( int i = pCount; i < 7; ++i ) {
+      for( int i = pCount; i < 7; ++i ) {
         int bitt = ctz(t0);     // get index
         t0 &= ~(1 << bitt); // clear bit set and test again
         int pri = bitState[bitt][0];
-        if ( pri < worst ) {
+        if( pri < worst ) {
           worst = pri;
           idx = bitt;
         }
@@ -201,7 +201,7 @@ public:
       tmp = _mm_packs_epi16(tmp, _mm_setzero_si128()); // pack result
       uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
       uint32_t a = 0;    // index into bitState or 7 if not found
-      if (t != 0u) {
+      if (t != 0u ) {
         a = (clz(t) - 1) & 7U;
         mostRecentlyUsed = mostRecentlyUsed << 4U | a;
         return &bitState[a][0];
@@ -220,11 +220,11 @@ public:
       __m128i sum1 = _mm_sad_epu8(lastX, _mm_setzero_si128());        // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
       const uint32_t pCount = _mm_cvtsi128_si32(sum1); // population count
       uint32_t t0 = (~_mm_movemask_epi8(eq0));
-      for ( int i = pCount; i < 7; ++i ) {
+      for( int i = pCount; i < 7; ++i ) {
         int bitt = ctz(t0);     // get index
         t0 &= ~(1 << bitt); // clear bit set and test again
         int pri = bitState[bitt][0];
-        if ( pri < worst ) {
+        if( pri < worst ) {
           worst = pri;
           idx = bitt;
         }
@@ -255,7 +255,7 @@ public:
       tmp = vreinterpretq_s32_s8(vcombine_s8(vqmovn_s16(vreinterpretq_s16_s32(tmp)), vqmovn_s16(vreinterpretq_s16_s32(vdupq_n_s32(0))))); // pack result
       uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
       uint32_t a = 0;    // index into bitState or 7 if not found
-      if (t != 0u ) {
+      if ( t != 0u ) {
         a = (clz(t) - 1) & 7U;
         mostRecentlyUsed = mostRecentlyUsed << 4U | a;
         return &bitState[a][0];
@@ -275,11 +275,11 @@ public:
       int32x4_t sum1 = _mm_sad_epu8(lastX, vdupq_n_s32(0)); // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
       const uint32_t pCount = vgetq_lane_s32(sum1, 0); // population count
       uint32_t t0 = (~_mm_movemask_epi8(eq0));
-      for ( int i = pCount; i < 7; ++i ) {
+      for( int i = pCount; i < 7; ++i ) {
         int bitt = ctz(t0);     // get index
         t0 &= ~(1 << bitt); // clear bit set and test again
         int pri = bitState[bitt][0];
-        if ( pri < worst ) {
+        if( pri < worst ) {
           worst = pri;
           idx = bitt;
         }

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -78,7 +78,7 @@ static inline int32x4_t _mm_shuffle_epi8(int32x4_t a, int32x4_t b)
     uint8x16_t idx = vreinterpretq_u8_s32(b);  // input b
     uint8x16_t idx_masked = vandq_u8(idx, vdupq_n_u8(0x8F));  // avoid using meaningless bits
 #if defined(__aarch64__)
-    return vreinterpretq_s64_s8(vqtbl1q_s8(tbl, idx_masked)); //function only exist on ARMv8
+    return vreinterpretq_s32_s8(vqtbl1q_s8(tbl, idx_masked)); //function only exist on ARMv8
 #elif defined(__GNUC__)
     int8x16_t ret;
     // %e and %f represent the even and odd D registers
@@ -88,11 +88,11 @@ static inline int32x4_t _mm_shuffle_epi8(int32x4_t a, int32x4_t b)
         "    vtbl.8  %f[ret], {%e[tbl], %f[tbl]}, %f[idx]\n"
         : [ret] "=&w" (ret)
         : [tbl] "w" (tbl), [idx] "w" (idx_masked));
-    return vreinterpretq_s64_s8(ret);
+    return vreinterpretq_s32_s8(ret);
 #else
     // use this line if testing on aarch64
     int8x8x2_t a_split = { vget_low_s8(tbl), vget_high_s8(tbl) };
-    return vreinterpretq_s64_s8(vcombine_s8(vtbl2_s8(a_split, vget_low_u8(idx_masked)), vtbl2_s8(a_split, vget_high_u8(idx_masked))));
+    return vreinterpretq_s32_s8(vcombine_s8(vtbl2_s8(a_split, vget_low_u8(idx_masked)), vtbl2_s8(a_split, vget_high_u8(idx_masked))));
 #endif
 }
 #endif

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -201,7 +201,7 @@ public:
       int32x4_t vm = _mm_setr_epi8(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
 
       int32x4_t lastX = vcombine_s64(vget_low_s64(vreinterpretq_s64_s32(lastL)), vget_low_s64(vreinterpretq_s64_s32(lastH))); // mostRecentlyUsed&15 mostRecentlyUsed>>4
-      int32x4_t eq0 = vreinterpretq_s64_u8(vceqq_s8(vreinterpretq_s8_s32(lastX), vreinterpretq_s8_s32(vm))); // compare values
+      int32x4_t eq0 = vreinterpretq_s32_u8(vceqq_s8(vreinterpretq_s8_s32(lastX), vreinterpretq_s8_s32(vm))); // compare values
 
       eq0 = vorrq_s32(eq0, _mm_srli_si128(eq0, 8));    // or low values with high
 

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -72,17 +72,6 @@ static inline int32x4_t _mm_sad_epu8(int32x4_t a, int32x4_t b)
     return (int32x4_t) vsetq_lane_u16(r4, r, 4);
 }
 
-static inline int _mm_movemask_epi8(int32x4_t a)
-{
-    uint8x16_t input = vreinterpretq_u8_s64(a);
-    uint16x8_t high_bits = vreinterpretq_u16_u8(vshrq_n_u8(input, 7));
-    uint32x4_t paired16 = vreinterpretq_u32_u16(vsraq_n_u16(high_bits, high_bits, 7));
-    uint64x2_t paired32 = vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
-    uint8x16_t paired64 = vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
-    return vgetq_lane_u8(paired64, 0) | ((int)vgetq_lane_u8(paired64, 8) << 8);
-}
-#endif
-
 static inline auto clz(uint32_t value) -> uint32_t {
   return __builtin_clz(value);
 }

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -136,7 +136,7 @@ public:
       /// load 8 values, discard last one as only 7 are needed.
       /// reverse order and compare 7 checksums values to @ref checksum
       /// get mask is set get first index and return value
-      __m256i tmp = _mm256_load_si256(reinterpret_cast<__m256i*>(&checksums[0]));
+      __m256i tmp = _mm256_load_si256(reinterpret_cast<__m256i *>(&checksums[0]));
       tmp = _mm256_shuffle_epi8(tmp, _mm256_setr_epi8(30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
       tmp = _mm256_cmpeq_epi16(tmp, xmmChecksum); // compare ch values
       tmp = _mm256_packs_epi16(tmp, _mm256_setzero_si256()); // pack result
@@ -163,11 +163,11 @@ public:
       const uint32_t pCount = _mm_cvtsi128_si32(_mm256_castsi256_si128(sum1)); // population count
       _mm256_zeroupper();
       uint32_t t0 = (~_mm256_movemask_epi8(eq0));
-      for (int i = pCount; i < 7; ++i) {
+      for ( int i = pCount; i < 7; ++i ) {
         int bitt = ctz(t0);     // get index
         t0 &= ~(1 << bitt); // clear bit set and test again
         int pri = bitState[bitt][0];
-        if (pri < worst) {
+        if ( pri < worst ) {
           worst = pri;
           idx = bitt;
         }
@@ -194,7 +194,7 @@ public:
       // load 8 values, discard last one as only 7 are needed.
       // reverse order and compare 7 checksums values to @ref checksum
       // get mask is set get first index and return value
-      __m128i tmp = _mm_load_si128(reinterpret_cast<__m128i*>(&checksums[0])); //load 8 values (8th will be discarded)
+      __m128i tmp = _mm_load_si128(reinterpret_cast<__m128i *>(&checksums[0])); //load 8 values (8th will be discarded)
 
       tmp = _mm_shuffle_epi8(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
       tmp = _mm_cmpeq_epi16(tmp, xmmChecksum); // compare ch values
@@ -220,11 +220,11 @@ public:
       __m128i sum1 = _mm_sad_epu8(lastX, _mm_setzero_si128());        // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
       const uint32_t pCount = _mm_cvtsi128_si32(sum1); // population count
       uint32_t t0 = (~_mm_movemask_epi8(eq0));
-      for (int i = pCount; i < 7; ++i) {
+      for ( int i = pCount; i < 7; ++i ) {
         int bitt = ctz(t0);     // get index
         t0 &= ~(1 << bitt); // clear bit set and test again
         int pri = bitState[bitt][0];
-        if (pri < worst) {
+        if ( pri < worst ) {
           worst = pri;
           idx = bitt;
         }
@@ -248,14 +248,14 @@ public:
       // load 8 values, discard last one as only 7 are needed.
       // reverse order and compare 7 checksums values to @ref checksum
       // get mask is set get first index and return value
-      int32x4_t tmp = vld1q_s32(reinterpret_cast<int32_t*>(&checksums[0])); //load 8 values (8th will be discarded)
+      int32x4_t tmp = vld1q_s32(reinterpret_cast<int32_t *>(&checksums[0])); //load 8 values (8th will be discarded)
       
       tmp = _mm_shuffle_epi8(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
       tmp = vreinterpretq_s32_u16(vceqq_s16(vreinterpretq_s16_s32(tmp), vreinterpretq_s16_s32(xmmChecksum))); // compare ch values
       tmp = vreinterpretq_s32_s8(vcombine_s8(vqmovn_s16(vreinterpretq_s16_s32(tmp)), vqmovn_s16(vreinterpretq_s16_s32(vdupq_n_s32(0))))); // pack result
       uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
       uint32_t a = 0;    // index into bitState or 7 if not found
-      if (t != 0u) {
+      if (t != 0u ) {
         a = (clz(t) - 1) & 7U;
         mostRecentlyUsed = mostRecentlyUsed << 4U | a;
         return &bitState[a][0];
@@ -275,11 +275,11 @@ public:
       int32x4_t sum1 = _mm_sad_epu8(lastX, vdupq_n_s32(0)); // count values, abs(a0 - b0) + abs(a1 - b1) .... up to b8
       const uint32_t pCount = vgetq_lane_s32(sum1, 0); // population count
       uint32_t t0 = (~_mm_movemask_epi8(eq0));
-      for (int i = pCount; i < 7; ++i) {
+      for ( int i = pCount; i < 7; ++i ) {
         int bitt = ctz(t0);     // get index
         t0 &= ~(1 << bitt); // clear bit set and test again
         int pri = bitState[bitt][0];
-        if (pri < worst) {
+        if ( pri < worst ) {
           worst = pri;
           idx = bitt;
         }
@@ -324,7 +324,7 @@ public:
         return findNeon(checksum);
       }
       assert(false);
-      return (uint8_t*) 0;
+      return (uint8_t *) 0;
     }
 };
 

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -201,7 +201,7 @@ public:
       tmp = _mm_packs_epi16(tmp, _mm_setzero_si128()); // pack result
       uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
       uint32_t a = 0;    // index into bitState or 7 if not found
-      if (t != 0u ) {
+      if( t != 0u ) {
         a = (clz(t) - 1) & 7U;
         mostRecentlyUsed = mostRecentlyUsed << 4U | a;
         return &bitState[a][0];

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -185,7 +185,7 @@ public:
       int32x4_t tmp = vld1q_s32(reinterpret_cast<int32_t*>(&checksums[0])); //load 8 values (8th will be discarded)
 
       tmp = _mm_shuffle_epi8(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
-      tmp = vceqq_s16(vreinterpretq_s16_s32(tmp), vreinterpretq_s16_s32(xmmChecksum)); // compare ch values
+      tmp = vceqq_s16(vreinterpretq_s8_s32(tmp), vreinterpretq_s16_s32(xmmChecksum)); // compare ch values
       tmp = vcombine_s8(vqmovn_s16(vreinterpretq_s16_s32(tmp)), vqmovn_s16(vreinterpretq_s16_s32(vdupq_n_s32(0)))); // pack result
       uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
       uint32_t a = 0;    // index into bitState or 7 if not found

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -24,7 +24,7 @@ static inline int32x4_t _mm_srli_si128(int32x4_t a, int imm) {
 
 static inline int _mm_movemask_epi8(int32x4_t _a)
 {
-    uint8x16_t input = vreinterpretq_u8_m128i(_a);
+    uint8x16_t input = vreinterpretq_u8_s32(_a);
     static const int8_t __attribute__((aligned(16))) xr[8] = { -7, -6, -5, -4, -3, -2, -1, 0 };
     uint8x8_t mask_and = vdup_n_u8(0x80);
     int8x8_t mask_shift = vld1_s8(xr);

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -185,8 +185,8 @@ public:
       int32x4_t tmp = vld1q_s32(reinterpret_cast<int32_t*>(&checksums[0])); //load 8 values (8th will be discarded)
 
       tmp = _mm_shuffle_epi8(tmp, _mm_setr_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
-      tmp = vceqq_s16(vreinterpretq_s8_s32(tmp), vreinterpretq_s16_s32(xmmChecksum)); // compare ch values
-      tmp = vcombine_s8(vqmovn_s16(vreinterpretq_s16_s32(tmp)), vqmovn_s16(vreinterpretq_s16_s32(vdupq_n_s32(0)))); // pack result
+      tmp = vreinterpretq_s32_u16(vceqq_s16(vreinterpretq_s16_s32(tmp), vreinterpretq_s16_s32(xmmChecksum))); // compare ch values
+      tmp = vreinterpretq_s32_s8(vcombine_s8(vqmovn_s16(vreinterpretq_s16_s32(tmp)), vqmovn_s16(vreinterpretq_s16_s32(vdupq_n_s32(0))))); // pack result
       uint32_t t = (_mm_movemask_epi8(tmp)) >> 1; // get mask of comparison, bit is set if eq, discard 8th bit
       uint32_t a = 0;    // index into bitState or 7 if not found
       if (t != 0u) {

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -50,10 +50,10 @@ static inline int _mm_movemask_epi8(int32x4_t _a)
 }
 
 // Below functions taken and adapted from https://github.com/DLTcollab/sse2neon/blob/master/sse2neon.h
-static inline int32x4_t _mm_set_epi8(signed char b15, signed char b14, signed char b13, signed char b12,
-    signed char b11, signed char b10, signed char b9, signed char b8,
-    signed char b7, signed char b6, signed char b5, signed char b4,
-    signed char b3, signed char b2, signed char b1, signed char b0)
+static inline int32x4_t _mm_setr_epi8(signed char b0, signed char b1, signed char b2, signed char b3,
+    signed char b4, signed char b5, signed char b6, signed char b7,
+    signed char b8, signed char b9, signed char b10, signed char b11,
+    signed char b12, signed char b13, signed char b14, signed char b15)
 {
     int8_t __attribute__((aligned(16)))
         data[16] = { (int8_t)b0,  (int8_t)b1,  (int8_t)b2,  (int8_t)b3,

--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -13,7 +13,7 @@
 #include <arm_neon.h>
 
 // Below functions taken and adapted from https://github.com/jratcliff63367/sse2neon/blob/master/SSE2NEON.h
-static inline int32x4_t _mm_srli_si128(a, imm) {
+static inline int32x4_t _mm_srli_si128(int32x4_t a, int imm) {
   if ((imm) <= 0)
     return a;
   else if ((imm) > 15)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1633,3 +1633,5 @@ paq8px_v187:
 2020.04.12
 - Ported ContextMap Bucket find() function to NEON and AVX2.
 - Bucket will now use the find() function according to the SIMD vectorization being used.
+- When using SSE2, it will assume the CPU doesn't have SSE3 and will use the `None` function of Bucket.hpp`. If `-simd SSSE3` is specified , then it will use the SSSE3 SIMD function in `Bucket.hpp` and the SSE2 Mixer Training function.
+- Changed some If's statements to If/Else.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1628,3 +1628,7 @@ paq8px_v186:
 paq8px_v186fix1:
 2020.04.10
 - Fixed infinite loop in base64 decoder.
+
+paq8px_v187:
+2020.04.11
+- Ported ContextMap Bucket find() function to NEON.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1631,4 +1631,4 @@ paq8px_v186fix1:
 
 paq8px_v187:
 2020.04.11
-- Ported ContextMap Bucket find() function to NEON.
+- Ported ContextMap Bucket find() function to NEON and AVX2.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1632,3 +1632,4 @@ paq8px_v186fix1:
 paq8px_v187:
 2020.04.11
 - Ported ContextMap Bucket find() function to NEON and AVX2.
+- Bucket will now use the find() function according to the SIMD vectorization being used.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1630,6 +1630,6 @@ paq8px_v186fix1:
 - Fixed infinite loop in base64 decoder.
 
 paq8px_v187:
-2020.04.11
+2020.04.12
 - Ported ContextMap Bucket find() function to NEON and AVX2.
 - Bucket will now use the find() function according to the SIMD vectorization being used.

--- a/ContextMap.cpp
+++ b/ContextMap.cpp
@@ -14,16 +14,16 @@ void ContextMap::set(const uint64_t cx) {
   assert(cn >= 0 && cn < c);
   const uint32_t ctx = cxt[cn] = finalize64(cx, hashBits);
   const uint16_t checksum = chk[cn] = static_cast<uint16_t>(checksum64(cx, hashBits, 16));
-  uint8_t *base = cp0[cn] = cp[cn] = t[ctx & mask].find(checksum);
+  uint8_t *base = cp0[cn] = cp[cn] = t[ctx & mask].find(checksum, shared->chosenSimd);
   runP[cn] = base + 3;
   // update pending bit histories for bits 2-7
   if( base[3] == 2 ) {
     const int c = base[4] + 256;
-    uint8_t *p = t[(ctx + (c >> 6U)) & mask].find(checksum);
+    uint8_t *p = t[(ctx + (c >> 6U)) & mask].find(checksum, shared->chosenSimd);
     p[0] = 1 + ((c >> 5U) & 1U);
     p[1 + ((c >> 5U) & 1U)] = 1 + ((c >> 4U) & 1U);
     p[3 + ((c >> 4U) & 3U)] = 1 + ((c >> 3U) & 1U);
-    p = t[(ctx + (c >> 3U)) & mask].find(checksum);
+    p = t[(ctx + (c >> 3U)) & mask].find(checksum, shared->chosenSimd);
     p[0] = 1 + ((c >> 2U) & 1U);
     p[1 + ((c >> 2U) & 1U)] = 1 + ((c >> 1U) & 1U);
     p[3 + ((c >> 1U) & 3U)] = 1 + (c & 1U);
@@ -67,7 +67,7 @@ void ContextMap::update() {
           case 5: {
             const uint16_t checksum = chk[i];
             const uint32_t ctx = cxt[i];
-            cp0[i] = cp[i] = t[(ctx + shared->c0) & mask].find(checksum);
+            cp0[i] = cp[i] = t[(ctx + shared->c0) & mask].find(checksum, shared->chosenSimd);
             break;
           }
           case 0: {

--- a/ContextMap2.cpp
+++ b/ContextMap2.cpp
@@ -27,18 +27,18 @@ void ContextMap2::set(const uint64_t ctx) {
   assert(index >= 0 && index < c);
   const uint32_t ctx0 = contexts[index] = finalize64(ctx, hashBits);
   const uint16_t chk0 = checksums[index] = static_cast<uint16_t>(checksum64(ctx, hashBits, 16));
-  uint8_t *base = bitState[index] = bitState0[index] = table[ctx0 & mask].find(chk0);
+  uint8_t *base = bitState[index] = bitState0[index] = table[ctx0 & mask].find(chk0, shared->chosenSimd);
   byteHistory[index] = &base[3];
   const uint8_t runCount = base[3];
   if( runCount == 255 ) { // pending
     // update pending bit histories for bits 2-7
     // in case of a collision updating (mixing) is slightly better (but slightly slower) then resetting, so we update
     const int c = base[4] + 256;
-    uint8_t *p1A = table[(ctx0 + (c >> 6U)) & mask].find(chk0);
+    uint8_t *p1A = table[(ctx0 + (c >> 6U)) & mask].find(chk0, shared->chosenSimd);
     StateTable::update(p1A, ((c >> 5U) & 1), rnd);
     StateTable::update(p1A + 1 + ((c >> 5) & 1), ((c >> 4) & 1), rnd);
     StateTable::update(p1A + 3 + ((c >> 4U) & 3), ((c >> 3) & 1), rnd);
-    uint8_t *p1B = table[(ctx0 + (c >> 3)) & mask].find(chk0);
+    uint8_t *p1B = table[(ctx0 + (c >> 3)) & mask].find(chk0, shared->chosenSimd);
     StateTable::update(p1B, (c >> 2) & 1, rnd);
     StateTable::update(p1B + 1 + ((c >> 2) & 1), (c >> 1) & 1, rnd);
     StateTable::update(p1B + 3 + ((c >> 1) & 3), c & 1, rnd);
@@ -99,7 +99,7 @@ void ContextMap2::update() {
           case 5: {
             const uint16_t chk = checksums[i];
             const uint32_t ctx = contexts[i];
-            bitState[i] = bitState0[i] = table[(ctx + shared->c0) & mask].find(chk);
+            bitState[i] = bitState0[i] = table[(ctx + shared->c0) & mask].find(chk, shared->chosenSimd);
             break;
           }
           case 1:

--- a/MixerFactory.cpp
+++ b/MixerFactory.cpp
@@ -8,7 +8,7 @@ auto MixerFactory::createMixer(const int n, const int m, const int s) -> Mixer *
     return new SIMDMixer<SIMD_SSE2>(n, m, s);
   }
   else if (shared->chosenSimd == SIMD_SSSE3) {
-      return new SIMDMixer<SIMD_SSSE3>(n, m, s);
+    return new SIMDMixer<SIMD_SSSE3>(n, m, s);
   }
   else if( shared->chosenSimd == SIMD_AVX2 ) {
     return new SIMDMixer<SIMD_AVX2>(n, m, s);

--- a/MixerFactory.cpp
+++ b/MixerFactory.cpp
@@ -4,13 +4,16 @@ auto MixerFactory::createMixer(const int n, const int m, const int s) -> Mixer *
   if( shared->chosenSimd == SIMD_NONE ) {
     return new SIMDMixer<SIMD_NONE>(n, m, s);
   }
-  if( shared->chosenSimd == SIMD_SSE2 ) {
+  else if( shared->chosenSimd == SIMD_SSE2 ) {
     return new SIMDMixer<SIMD_SSE2>(n, m, s);
   }
-  if( shared->chosenSimd == SIMD_AVX2 ) {
+  else if (shared->chosenSimd == SIMD_SSSE3) {
+      return new SIMDMixer<SIMD_SSSE3>(n, m, s);
+  }
+  else if( shared->chosenSimd == SIMD_AVX2 ) {
     return new SIMDMixer<SIMD_AVX2>(n, m, s);
   }
-  if (shared->chosenSimd == SIMD_NEON) {
+  else if (shared->chosenSimd == SIMD_NEON) {
     return new SIMDMixer<SIMD_NEON>(n, m, s);
   }
   assert(false);

--- a/SimdMixer.hpp
+++ b/SimdMixer.hpp
@@ -19,10 +19,10 @@ private:
       if( simd == SIMD_AVX2 ) {
         return 32 / sizeof(short); // 256 bit (32 byte) data size
       }
-      if( simd == SIMD_SSE2 || simd == SIMD_NEON ) {
+      else if( simd == SIMD_SSE2 || simd == SIMD_SSSE3 || simd == SIMD_NEON ) {
         return 16 / sizeof(short); // 128 bit (16 byte) data size
       }
-      if( simd == SIMD_NONE ) {
+      else if( simd == SIMD_NONE ) {
         return 4 / sizeof(short); // Processes 2 shorts at once -> width is 4 bytes
       }
       assert(false);
@@ -64,13 +64,13 @@ public:
           if( simd == SIMD_NONE ) {
             trainSimdNone(&tx[0], &wx[cxt[i] * n], nx, err * rates[i]);
           }
-          if( simd == SIMD_SSE2 ) {
+          else if( simd == SIMD_SSE2 || simd == SIMD_SSSE3 ) {
             trainSimdSse2(&tx[0], &wx[cxt[i] * n], nx, err * rates[i]);
           }
-          if( simd == SIMD_AVX2 ) {
+          else if( simd == SIMD_AVX2 ) {
             trainSimdAvx2(&tx[0], &wx[cxt[i] * n], nx, err * rates[i]);
           }
-          if (simd == SIMD_NEON) {
+          else if (simd == SIMD_NEON) {
             trainSimdNeon(&tx[0], &wx[cxt[i] * n], nx, err * rates[i]);
           }
           if((shared->options & OPTION_ADAPTIVE) != 0u ) {
@@ -116,13 +116,13 @@ public:
           if( simd == SIMD_NONE ) {
             dp = dotProductSimdNone(&tx[0], &wx[cxt[i] * n], nx);
           }
-          if( simd == SIMD_SSE2 ) {
+          else if( simd == SIMD_SSE2 || simd == SIMD_SSSE3 ) {
             dp = dotProductSimdSse2(&tx[0], &wx[cxt[i] * n], nx);
           }
-          if( simd == SIMD_AVX2 ) {
+          else if( simd == SIMD_AVX2 ) {
             dp = dotProductSimdAvx2(&tx[0], &wx[cxt[i] * n], nx);
           }
-          if (simd == SIMD_NEON) {
+          else if (simd == SIMD_NEON) {
             dp = dotProductSimdNeon(&tx[0], &wx[cxt[i] * n], nx);
           }
           dp = (dp * scaleFactor) >> 16U;
@@ -141,13 +141,13 @@ public:
       if( simd == SIMD_NONE ) {
         dp = dotProductSimdNone(&tx[0], &wx[cxt[0] * n], nx);
       }
-      if( simd == SIMD_SSE2 ) {
+      else if( simd == SIMD_SSE2 || simd == SIMD_SSSE3 ) {
         dp = dotProductSimdSse2(&tx[0], &wx[cxt[0] * n], nx);
       }
-      if( simd == SIMD_AVX2 ) {
+      else if( simd == SIMD_AVX2 ) {
         dp = dotProductSimdAvx2(&tx[0], &wx[cxt[0] * n], nx);
       }
-      if (simd == SIMD_NEON) {
+      else if (simd == SIMD_NEON) {
         dp = dotProductSimdNeon(&tx[0], &wx[cxt[0] * n], nx);
       }
       dp = (dp * scaleFactor) >> 16U;

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -118,7 +118,7 @@ static void printHelp() {
          "    Logs (appends) compression results in the specified tab separated LOGFILE.\n"
          "    Logging is only applicable for compression.\n"
          "\n"
-         "    -simd [NONE|SSE2|AVX2|NEON]\n"
+         "    -simd [NONE|SSE2|SSSE3|AVX2|NEON]\n"
          "    Overrides detected SIMD instruction set for neural network operations\n"
          "\n"
          "Remark: the command line arguments may be used in any order except the input\n"
@@ -167,6 +167,8 @@ static void printSimdInfo(int simdIset, int detectedSimdIset) {
     printf("NEON");
   } else if( simdIset >= 9 ) {
     printf("AVX2");
+  } else if (simdIset >= 5) {
+    printf("SSSE3 & SSE2");
   } else if( simdIset >= 3 ) {
     printf("SSE2");
   } else {
@@ -311,20 +313,20 @@ auto main_utf8(int argc, char **argv) -> int {
 #endif
         else if( strcasecmp(argv[i], "-simd") == 0 ) {
           if( ++i == argc ) {
-            quit("The -simd switch requires an instruction set name (NONE,SSE2,AVX2,NEON).");
+            quit("The -simd switch requires an instruction set name (NONE,SSE2,SSSE3, AVX2, NEON).");
           }
           if( strcasecmp(argv[i], "NONE") == 0 ) {
             simdIset = 0;
           } else if( strcasecmp(argv[i], "SSE2") == 0 ) {
             simdIset = 3;
-          } else if( strcasecmp(argv[i], "AVX2") == 0 ) {
-            simdIset = 9;
+          } else if( strcasecmp(argv[i], "SSSE3") == 0 ) {
+            simdIset = 5;
          } else if( strcasecmp(argv[i], "AVX2") == 0 ) {
             simdIset = 9;
          } else if (strcasecmp(argv[i], "NEON") == 0) {
             simdIset = 11;
           } else {
-            quit("Invalid -simd option. Use -simd NONE, -simd SSE2, -simd AVX2 or -simd NEON.");
+            quit("Invalid -simd option. Use -simd NONE, -simd SSE2, -simd SSSE3, -simd AVX2 or -simd NEON.");
           }
         } else {
           printf("Invalid command: %s", argv[i]);
@@ -366,6 +368,8 @@ auto main_utf8(int argc, char **argv) -> int {
       shared->chosenSimd = SIMD_NEON;
     } else if (simdIset >= 9) {
       shared->chosenSimd = SIMD_AVX2;
+    } else if (simdIset >= 5) {
+      shared->chosenSimd = SIMD_SSSE3;
     } else if( simdIset >= 3 ) {
       shared->chosenSimd = SIMD_SSE2;
     } else {

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "186fix1"  //update version here before publishing your changes
+#define PROGVERSION  "187"  //update version here before publishing your changes
 #define PROGYEAR     "2020"
 
 // TODO: make more models "optional"

--- a/utils.hpp
+++ b/utils.hpp
@@ -74,7 +74,7 @@ static_assert(sizeof(int) == 4, "sizeof(int)");
 #define DEFAULT_LEARNING_RATE 7
 
 typedef enum {
-    SIMD_NONE, SIMD_SSE2, SIMD_AVX2, SIMD_NEON
+    SIMD_NONE, SIMD_SSE2, SIMD_SSSE3, SIMD_AVX2, SIMD_NEON
 } SIMD;
 
 struct ErrorInfo {


### PR DESCRIPTION
paq8px_v187:
2020.04.12
* Ported ContextMap Bucket find() function to NEON and AVX2.
* Bucket will now use the find() function according to the SIMD vectorization being used.
* When using SSE2, it will assume the CPU doesn't have SSSE3 and will use the `None` function of `Bucket.hpp`. If `-simd SSSE3` is specified , then it will use the SSSE3 SIMD function in `Bucket.hpp` and the SSE2 Mixer Training function.
* Changed some If's statements to If/Else .