### PR TITLE
V187fix3: Restored compilation on ARM processors

### DIFF
--- a/Bucket.hpp
+++ b/Bucket.hpp
@@ -118,7 +118,7 @@ public:
      * @return
      */
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
     __attribute__((target("ssse3")))
 #endif
     inline auto findSsse3(const uint16_t checksum) -> uint8_t* {

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1665,3 +1665,7 @@ paq8px_v187fix2
 2020.06.09
 - Fixed string copy issue in "OpenFromMyFolder.hpp" that caused text pretraining to malfunction.
 - Enabled compression levels up to 12 (~ 28-32 GB depending on the models loaded)
+
+paq8px_v187fix3
+2020.06.09
+- Restored compilation on ARM processors using GCC (Must use -DNATIVECPU=ON on cmake).

--- a/Mixer.hpp
+++ b/Mixer.hpp
@@ -11,7 +11,7 @@
 #include <arm_neon.h>
 #endif
 
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("avx2")))
 #endif
 static auto dotProductSimdAvx2(const short *const t, const short *const w, int n) -> int {

--- a/Mixer.hpp
+++ b/Mixer.hpp
@@ -11,7 +11,7 @@
 #include <arm_neon.h>
 #endif
 
-#if defined(__GNUC__) || defined(__clang__) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
+#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("avx2")))
 #endif
 static auto dotProductSimdAvx2(const short *const t, const short *const w, int n) -> int {

--- a/Mixer.hpp
+++ b/Mixer.hpp
@@ -36,7 +36,7 @@ static auto dotProductSimdAvx2(const short *const t, const short *const w, int n
 #endif
 }
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("avx2")))
 #endif
 static void trainSimdAvx2(const short *const t, short *const w, int n, const int e) {
@@ -93,7 +93,7 @@ static auto dotProductSimdNeon(const short *const t, const short *const w, int n
 }
 
 static void trainSimdNeon(const short *const t, short *const w, int n, const int e) {
-#if !defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON)
+#if (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
   return;
 #else
   const int32x4_t one = vreinterpretq_s32_s16(vdupq_n_s16(1));
@@ -110,7 +110,7 @@ static void trainSimdNeon(const short *const t, short *const w, int n, const int
 #endif
 }
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("sse2")))
 #endif
 static auto dotProductSimdSse2(const short *const t, const short *const w, int n) -> int {
@@ -131,7 +131,7 @@ static auto dotProductSimdSse2(const short *const t, const short *const w, int n
 #endif
 }
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("sse2")))
 #endif
 static void trainSimdSse2(const short *const t, short *const w, int n, const int e) {

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "187fix2"  //update version here before publishing your changes
+#define PROGVERSION  "187fix3"  //update version here before publishing your changes
 #define PROGYEAR     "2020"
 
 

--- a/simd.hpp
+++ b/simd.hpp
@@ -2,7 +2,7 @@
 #define PAQ8PX_SIMD_HPP
 
 ///////////////////////// SIMD Vectorization detection //////////////////////////////////
-
+#if (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 // Uncomment one or more of the following includes if you plan adding more SIMD dispatching
 //#include <mmintrin.h>  //MMX
 //#include <xmmintrin.h> //SSE
@@ -14,6 +14,7 @@
 //#include <ammintrin.h> //SSE4A
 #include <immintrin.h> //AVX, AVX2
 //#include <zmmintrin.h> //AVX512
+#endif
 
 //define CPUID
 #if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
- Restored compilation on ARM processors using GCC (Must use -DNATIVECPU=ON on cmake).