### PR TITLE
-V arg update: will now print compression level -12 instead of -9

### DIFF
--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -404,7 +404,7 @@ auto processCommandLine(int argc, char **argv) -> int {
     // Successfully parsed command line arguments
     // Let's check their validity
     if( whattodo == DoNone ) {
-      quit("A command switch is required: -0..-9 to compress, -d to decompress, -t to test, -l to list.");
+      quit("A command switch is required: -0..-12 to compress, -d to decompress, -t to test, -l to list.");
     }
     if( input.strsize() == 0 ) {
       printf("\nAn %s is required %s.\n", whattodo == DoCompress ? "input file or filelist" : "archive filename",


### PR DESCRIPTION
Since levels 10 to 12 were added to paq8px, the -V flag still printed compression levels 0 to 9. This PR updates it so that it will mention up to compression level 12.