### PR TITLE
paq8px_v196

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1803,4 +1803,15 @@ paq8px_v194 by Zoltán Gotthardt
 
 paq8px_v195 by Surya Kandau
 2020.10.23
-- Improve jpeg recompression
+- Improved jpeg recompression
+
+
+paq8px_v196 by Zoltán Gotthardt
+2020.10.25
+Fixes and improvements in jpeg model
+- fixed indexing (thank you, mpais!)
+- removed 2 contexts and 1 apm, added 1 context
+- hashing instead of direct contexts in apms (thank you, Kaitz!)
+- using abs for advPred[] and lcp[] in apms (thank you, Kaitz!)
+- reduced memory use in apms (-24 MB on level 8)
+- tweaks

--- a/model/ContextModel.cpp
+++ b/model/ContextModel.cpp
@@ -179,23 +179,12 @@ auto ContextModel::p() -> int {
     case JPEG: {
       JpegModel &jpegModel = models.jpegModel();
       if( jpegModel.mix(*m) != 0 ) {
-        m->setScaleFactor(1024, 256);
+        m->setScaleFactor(1024, 256); //850 for larger files, 1400 for smaller files - very sensitive
         return m->p();
       }
+      break;
     }
-    case DEFAULT:
-    case HDR:
-    case FILECONTAINER:
-    case EXE:
-    case CD:
-    case ZLIB:
-    case BASE64:
-    case GIF:
-    case TEXT:
-    case TEXT_EOL:
-    case RLE:
-    case LZW:
-    case DEC_ALPHA:
+    default:
       break;
   }
 

--- a/model/JpegModel.hpp
+++ b/model/JpegModel.hpp
@@ -76,9 +76,9 @@ struct JPEGImage {
  */
 class JpegModel {
 private:
-    static constexpr int N = 50; // number of contexts
+    static constexpr int N = 49; // number of contexts
 public:
-    static constexpr int MIXERINPUTS = 2 * N + 19;
+    static constexpr int MIXERINPUTS = 2 * N + 17;
     static constexpr int MIXERCONTEXTS = (1 + 8) + (1 + 1024) + 1024 + 1024;
     static constexpr int MIXERCONTEXTSETS = 4;
 
@@ -154,7 +154,7 @@ private:
     IndirectMap MJPEGMap;
     StateMap sm;
     Mixer *m1;
-    APM apm1, apm2, apm3, apm4, apm5, apm6, apm7, apm8, apm9, apm10, apm11, apm12, apm13, apm14, apm15;
+    APM apm1, apm2, apm3, apm4, apm5, apm6, apm7, apm8, apm9, apm10, apm11, apm12, apm13, apm14;
     Ilog *ilog = &Ilog::getInstance();
     Shared * const shared;
 

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "195"  //update version here before publishing your changes
+#define PROGVERSION  "196"  //update version here before publishing your changes
 #define PROGYEAR     "2020"
 
 


### PR DESCRIPTION
Fixes and improvements in jpeg model
- fixed indexing (thank you, mpais!)
- removed 2 contexts and 1 apm, added 1 context
- hashing instead of direct contexts in apms (thank you, Kaitz!)
- using abs for advPred[] and lcp[] in apms (thank you, Kaitz!)
- reduced memory use in apms (-24 MB on level 8)
- tweaks