### PR TITLE
paq8px_v200

### DIFF
--- a/Bucket16.hpp
+++ b/Bucket16.hpp
@@ -47,17 +47,20 @@ public:
   }
 
   T* find(uint16_t checksum, Random* rnd) {
+
     checksum += checksum == 0; //don't allow 0 checksums (0 checksums are used for empty slots)
-    for (size_t i = 0; i < ElementsInBucket; ++i) {
+
+    if (elements[0].checksum == checksum) //there is a high chance that we'll find it in the first slot, so go for it
+      return &elements[0].value;
+
+    for (size_t i = 1; i < ElementsInBucket; ++i) {
       if (elements[i].checksum == checksum) { // found matching checksum
-        if (i != 0) {
-          T value = elements[i].value;
-          //shift elements down
-          memmove(&elements[1], &elements[0], i * sizeof(HashElement<T>));
-          //move element to front (re-create)
-          elements[0].checksum = checksum;
-          elements[0].value = value;
-        }
+        T value = elements[i].value;
+        //shift elements down
+        memmove(&elements[1], &elements[0], i * sizeof(HashElement<T>));
+        //move element to front (re-create)
+        elements[0].checksum = checksum;
+        elements[0].value = value;
         return &elements[0].value;
       }
       if (elements[i].checksum == 0) { // found empty slot

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1848,3 +1848,10 @@ paq8px_v199 by Zoltán Gotthardt
 - NormalModel now includes the BlockType in its contexts
 - Introducing probabilistic hash replacement strategy for ContextMap, ContextMap2 and LargeStationaryMap
 - Other small fixes and cosmetic changes
+
+
+paq8px_v200 by Zoltán Gotthardt
+2020.12.31
+- Speed improvements in ContextMap and ContextMap2
+- In ContextMap2 updating bit histories for bits 2-7 was deferred for the first byte; now it is deferred for the first 3 bytes (both speed and compression improvement)
+- Small speed improvement in Bucket16

--- a/ContextMap.hpp
+++ b/ContextMap.hpp
@@ -88,8 +88,7 @@ private:
     Random rnd;
     const int C; /**< max number of contexts */
     Array<Bucket16<HashElementForContextMap, 7>> t; /**< bit and byte histories (statistics) */
-    Array<uint8_t *> cp; /**< c pointers to current bit history */
-    Array<uint8_t *> cp0; /**< First element of 7 element array containing cp[i] */
+    Array<uint8_t *> cp; /**< @ref C pointers to current bit history */
     Array<uint32_t> cxt; /**< c whole byte context hashes */
     Array<uint16_t> chk; /**< c whole byte context checksums */
     Array<uint8_t *> runP; /**< c [0..3] = count, value, unused, unused */

--- a/HashElementForContextMap.hpp
+++ b/HashElementForContextMap.hpp
@@ -5,30 +5,27 @@
 #include "StateTable.hpp"
 
 struct HashElementForContextMap { // sizeof(HashElemetForContextMap) = 7
+  uint8_t bitState;  // state of bit0 (1st slot) / state of bit2 (2nd slot)  /  state of bit5 (in slot 2)
+  uint8_t bitState0; // state of bit1 when bit0 was 0 (1st slot)  /  state of bit3 when bit2 was 0 (2nd slot)  /  state of bit6 when bit5 was 0 (3rd slot)
+  uint8_t bitState1; // state of bit1 when bit0 was 1 (1st slot)  /  state of bit3 when bit2 was 1 (2nd slot)  /  state of bit6 when bit5 was 1 (3rd slot)
   union {
-    struct {
-      uint8_t bit;
-      uint8_t bit0;
-      uint8_t bit1;
-      uint8_t count;
-      uint8_t value;
-      uint8_t unused1;
-      uint8_t unused2;
+    struct { // information in 1st slot
+      uint8_t runcount; // run count of byte1
+      uint8_t byte1; // the last seen byte
+      uint8_t byte2; 
+      uint8_t byte3;
     } byteStats;
-    struct {
-      uint8_t bit;
-      uint8_t bit0;
-      uint8_t bit1;
-      uint8_t bit00;
-      uint8_t bit01;
-      uint8_t bit10;
-      uint8_t bit11;
-    } bitStats;
+    struct { // information in 2nd and 3rd slots
+      uint8_t bitState00; // state of bit4 when bit2+bit3 was 00 (2nd slot)  /  state of bit7 when bit5+bit6 was 00 (3rd slot)
+      uint8_t bitState01; // state of bit4 when bit2+bit3 was 01 (2nd slot)  /  state of bit7 when bit5+bit6 was 01 (3rd slot)
+      uint8_t bitState10; // state of bit4 when bit2+bit3 was 10 (2nd slot)  /  state of bit7 when bit5+bit6 was 10 (3rd slot)
+      uint8_t bitState11; // state of bit4 when bit2+bit3 was 11 (2nd slot)  /  state of bit7 when bit5+bit6 was 11 (3rd slot)
+    } bitStates;
   };
 
   // priority for hash replacement strategy
   inline uint8_t prio() {
-    return StateTable::prio(byteStats.bit);
+    return StateTable::prio(bitState);
   }
 };
 

--- a/StateMap.cpp
+++ b/StateMap.cpp
@@ -9,9 +9,9 @@ StateMap::StateMap(const Shared* const sh, const int s, const int n, const int l
   assert(limit > 0 && limit < 1024);
   if( mapType == BitHistory ) { // when the context is a bit history byte, we have a-priory for p
     assert((numContextsPerSet & 255) == 0);
-    for( uint32_t cx = 0; cx < numContextsPerSet; ++cx ) {
+    for( uint64_t cx = 0; cx < numContextsPerSet; ++cx ) {
       auto state = uint8_t(cx & 255);
-      for ( uint32_t s = 0; s < numContextSets; ++s ) {
+      for ( uint64_t s = 0; s < numContextSets; ++s ) {
         uint32_t n0 = StateTable::next(state, 2);
         uint32_t n1 = StateTable::next(state, 3);
         uint32_t p;
@@ -39,7 +39,7 @@ StateMap::StateMap(const Shared* const sh, const int s, const int n, const int l
       }
     }
   } else if( mapType == Run ) { // when the context is a run count: we have a-priory for p
-    for( uint32_t cx = 0; cx < numContextsPerSet; ++cx ) {
+    for( uint64_t cx = 0; cx < numContextsPerSet; ++cx ) {
       const int predictedBit = (cx) & 1;
       const int uncertainty = (cx >> 1) & 1;
       //const int bp = (cx>>2)&1; // unused in calculation - a-priory does not seem to depend on bitPosition in the general case
@@ -49,7 +49,7 @@ StateMap::StateMap(const Shared* const sh, const int s, const int n, const int l
       if( predictedBit == 0 ) {
         std::swap(n0, n1);
       }
-      for( uint32_t s = 0; s < numContextSets; ++s ) {
+      for( uint64_t s = 0; s < numContextSets; ++s ) {
         t[s * numContextsPerSet + cx] = ((n1 << 20) / (n0 + n1)) << 12 | min(runCount, limit);
       }
     }

--- a/StateMap.hpp
+++ b/StateMap.hpp
@@ -29,8 +29,6 @@ public:
      */
     StateMap(const Shared* const sh, int s, int n, int lim, MAPTYPE mapType);
 
-    void reset(int rate);
-
     void update() override;
 
     /**

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "199"  //update version here before publishing your changes
+#define PROGVERSION  "200"  //update version here before publishing your changes
 #define PROGYEAR     "2020"
 
 

--- a/utils.hpp
+++ b/utils.hpp
@@ -41,6 +41,18 @@ static_assert(sizeof(int) == 4, "sizeof(int)");
 #define ALWAYS_INLINE inline
 #endif
 
+
+#if defined(NDEBUG)
+#if defined(_MSC_VER)
+#define assume(cond) __assume(cond)
+#else
+#define assume(cond) do { if (!(cond)) __builtin_unreachable(); } while (0)
+#endif
+#else
+#include <cassert>
+#define assume(cond) assert(cond)
+#endif
+
 #include <algorithm>
 #include <cstdio>
 // Determining the proper printf() format specifier for 64 bit unsigned integers:


### PR DESCRIPTION
- Speed improvements in ContextMap and ContextMap2
- In ContextMap2 updating bit histories for bits 2-7 was deferred for the first byte; now it is deferred for the first 3 bytes (both speed and compression improvement)
- Small speed improvement in Bucket16