### PR TITLE
paq8px_v201

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1677,7 +1677,7 @@ paq8px_v187fix2 by Zoltán Gotthardt
 - Enabled compression levels up to 12 (10 => 7-8 GB, 11 => 14-16 GB, 12 => ~ 28-32 GB depending on the models loaded)
 
 
-paq8px_v187fix3 by Zoltán Gotthardt
+paq8px_v187fix3 by Moisés Cardona
 2020.06.09
 - Restored compilation on ARM processors using GCC (Must use -DNATIVECPU=ON on cmake).
 
@@ -1855,3 +1855,15 @@ paq8px_v200 by Zoltán Gotthardt
 - Speed improvements in ContextMap and ContextMap2
 - In ContextMap2 updating bit histories for bits 2-7 was deferred for the first byte; now it is deferred for the first 3 bytes (both speed and compression improvement)
 - Small speed improvement in Bucket16
+
+
+paq8px_v201 by Zoltán Gotthardt
+2021.01.16
+- IndirectContext improvement: using a leading bit to distinguish context bits from empty (unused) bits
+- LSTM model: Applied the new IndirectContext improvements
+- MatchModel improvements: 
+  - moved context hashes from NormalModel to Shared so MatchModel can also use them
+  - using more candidates in hashtable (3 instead of 1)
+  - using the improved IndirectContext
+  - refined contexts
+  - tuned NormalModel contexts wrt MatchModel context lengths

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ option(DISABLE_AUDIOMODEL "Whether to disable AudioModels" OFF)
 option(DISABLE_ZLIB "Whether to disable zlib" OFF)
 option(NDEBUG "Whether to suppress asserts and array bound checks" ON)
 option(VERBOSE "Whether to print verbose debug information to screen" OFF)
-option(HASHCONFIGCMD "Whether to support custom hash configuration" OFF)
 
 if (NATIVECPU)
     add_definitions(-march=native -mtune=native)
@@ -38,10 +37,6 @@ endif (NDEBUG)
 if (VERBOSE)
     add_definitions(-DVERBOSE)
 endif (VERBOSE)
-
-if (HASHCONFIGCMD)
-    add_definitions(-DHASHCONFIGCMD)
-endif (HASHCONFIGCMD)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/ContextMap2.cpp
+++ b/ContextMap2.cpp
@@ -64,6 +64,7 @@ void ContextMap2::set(uint8_t ctxflags, const uint64_t contexthash) {
 void ContextMap2::skip(const uint8_t ctxflags) {
   assert(index >= 0 && index < C);
   contextInfoList[index].flags = ctxflags | CM_SKIPPED_CONTEXT;
+  contextflagsAll |= ctxflags;
   index++;
 }
 
@@ -172,6 +173,8 @@ void ContextMap2::update() {
           }
         }
         else {
+          //when pbos==2: switch from slot 0 to slot 1
+          //when bpos==5: switch from slot 1 to slot 2
           const uint32_t ctx = contextInfo->tableIndex;
           const uint16_t chk = contextInfo->tableChecksum;
           contextInfo->slot012 = hashTable[(ctx + c0) & mask].find(chk, &rnd);

--- a/HashElementForMatchPositions.hpp
+++ b/HashElementForMatchPositions.hpp
@@ -1,0 +1,17 @@
+#ifndef PAQ8PX_HASHELEMENTFORMATCHPOSITIONS_HPP
+#define PAQ8PX_HASHELEMENTFORMATCHPOSITIONS_HPP
+
+#include <cstdint>
+
+struct HashElementForMatchPositions { // sizeof(HashElementForMatchPositions) = 3*4 = 12
+  static constexpr size_t N = 3;
+  uint32_t matchPositions[N];
+  void Add(uint32_t pos) {
+    if (N > 1) {
+      memmove(&matchPositions[1], &matchPositions[0], (N - 1) * sizeof(matchPositions[0]));
+    }
+    matchPositions[0] = pos;
+  }
+};
+
+#endif //PAQ8PX_HASHELEMENTFORMATCHPOSITIONS_HPP

--- a/Models.cpp
+++ b/Models.cpp
@@ -54,7 +54,7 @@ auto Models::sparseModel() -> SparseModel & {
 }
 
 auto Models::matchModel() -> MatchModel & {
-  static MatchModel instance {shared, shared->mem * 4 /*buffermemorysize*/, shared->mem / 32 /*mapmemorysize*/ };
+  static MatchModel instance {shared, shared->mem / 4 /*hashtablesize*/, shared->mem /*mapmemorysize*/ }; /**< Not the actual memory use - see in the model */
   return instance;
 }
 

--- a/README
+++ b/README
@@ -119,6 +119,9 @@ For the help screen just launch PAQ8PX from the command line without any options
 HOW TO COMPILE
 --------------
 
+Building PAQ8PX requires a C++17 capable C++ compiler:
+https://en.cppreference.com/w/cpp/compiler_support#cpp17
+
 Windows 
 If you are a Windows user you don't need to compile the source. Just grab the latest
 executable bundled with the source from the https://encode.su/threads/342-paq8px thread.
@@ -130,7 +133,6 @@ Linux/macOS
 gcc/clang users on Linux/macOS may use the following commands to build:
 
  sudo apt-get install build-essential zlib1g-dev cmake make
- mkdir build
  cd build
  cmake ..
  make

--- a/SSE.cpp
+++ b/SSE.cpp
@@ -39,12 +39,12 @@ auto SSE::p(int pr0) -> int {
       int limit = 0x3FFU >> (static_cast<int>(blockPos < 0xFFF) * 2);
       pr = Text.APMs[0].p(pr0, (c0 << 8U) | (shared->State.Text.mask & 0xFU) | ((shared->State.misses & 0xFU) << 4U), limit);
       pr1 = Text.APMs[1].p(pr0, finalize64(hash(bpos, shared->State.misses & 3U, c4 & 0xffffU, shared->State.Text.mask >> 4U), 16), limit);
-      pr2 = Text.APMs[2].p(pr0, finalize64(hash(c0, shared->State.Match.expectedByte, shared->State.Match.length3), 16), limit);
+      pr2 = Text.APMs[2].p(pr0, finalize64(hash(c0, shared->State.Match.expectedByte << 2 | shared->State.Match.length3), 16), limit);
       pr3 = Text.APMs[3].p(pr0, finalize64(hash(c0, c4 & 0xffffU, shared->State.Text.firstLetter), 16), limit);
 
       pr0 = (pr0 + pr1 + pr2 + pr3 + 2) >> 2U;
 
-      pr1 = Text.APM1s[0].p(pr0, finalize64(hash(shared->State.Match.expectedByte, shared->State.Match.length3, c4 & 0xffU), 16));
+      pr1 = Text.APM1s[0].p(pr0, finalize64(hash(shared->State.Match.expectedByte << 2 | shared->State.Match.length3, c4 & 0xffU), 16));
       pr2 = Text.APM1s[1].p(pr, finalize64(hash(c0, c4 & 0x00ffffffU), 16));
       pr3 = Text.APM1s[2].p(pr, finalize64(hash(c0, c4 & 0xffffff00U), 16));
 

--- a/Shared.cpp
+++ b/Shared.cpp
@@ -24,7 +24,7 @@ void Shared::init(uint8_t level) {
   this->level = level;
   mem = UINT64_C(65536) << level;
   buf.setSize(static_cast<uint32_t>(min(mem * 8, UINT64_C(1) << 30))); /**< no reason to go over 1 GB */
-  toScreen = !isOutputDirected();
+  toScreen = !isOutputRedirected();
 }
 
 void Shared::update(int y) {
@@ -56,7 +56,7 @@ UpdateBroadcaster *Shared::GetUpdateBroadcaster() const {
   return updater;
 }
 
-auto Shared::isOutputDirected() -> bool {
+auto Shared::isOutputRedirected() -> bool {
 #ifdef WINDOWS
   DWORD FileType = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
   return (FileType == FILE_TYPE_PIPE) || (FileType == FILE_TYPE_DISK);

--- a/Shared.hpp
+++ b/Shared.hpp
@@ -59,8 +59,8 @@ public:
 
       //MatchModel
       struct {
-        uint32_t length3; //used by SSE stage and RecordModel
-        uint8_t expectedByte; //used by SSE stage
+        uint32_t length3;     //used by SSE stage and RecordModel
+        uint8_t expectedByte; //used by SSE stage and RecordModel
       } Match{};
 
       //NormalModel

--- a/Shared.hpp
+++ b/Shared.hpp
@@ -118,7 +118,7 @@ public:
     } State{};
 
     Shared() {
-      toScreen = !isOutputDirected();
+      toScreen = !isOutputRedirected();
     }
     void init(uint8_t level);
     void update(int y);
@@ -140,7 +140,7 @@ private:
      * Determine if output is redirected
      * @return
      */
-    static auto isOutputDirected() -> bool;
+    static auto isOutputRedirected() -> bool;
 
     static Shared *mPInstance;
 };

--- a/Shared.hpp
+++ b/Shared.hpp
@@ -65,6 +65,8 @@ public:
 
       //NormalModel
       int order{};
+      uint64_t cxt[15]{}; // context hashes
+
 
       //image models
       struct {

--- a/filter/eol.hpp
+++ b/filter/eol.hpp
@@ -14,7 +14,7 @@ public:
     void encode(File *in, File *out, uint64_t size, int /*info*/, int & /*headerSize*/) override {
       uint8_t b = 0;
       uint8_t pB = 0;
-      for( int i = 0; i < static_cast<int>(size); i++ ) {
+      for( uint64_t i = 0; i < size; i++ ) {
         b = in->getchar();
         if( pB == CARRIAGE_RETURN && b != NEW_LINE ) {
           out->putChar(pB);
@@ -32,7 +32,7 @@ public:
     auto decode(File * /*in*/, File *out, FMode fMode, uint64_t size, uint64_t &diffFound) -> uint64_t override {
       uint8_t b = 0;
       uint64_t count = 0;
-      for( int i = 0; i < static_cast<int>(size); i++, count++ ) {
+      for( uint64_t i = 0; i < size; i++, count++ ) {
         if((b = encoder->decompressByte()) == NEW_LINE ) {
           if( fMode == FDECOMPRESS ) {
             out->putChar(CARRIAGE_RETURN);

--- a/lstm/LstmModel.hpp
+++ b/lstm/LstmModel.hpp
@@ -18,7 +18,7 @@ protected:
   const Shared* const shared;
   std::valarray<float> probs;
   APM apm1, apm2, apm3;
-  IndirectContext<std::uint32_t> iCtx;
+  IndirectContext<std::uint16_t> iCtx;
   std::size_t top, mid, bot;
   std::uint8_t expected;
 public:
@@ -31,11 +31,13 @@ public:
     float const gradient_clip) :
     shared(sh),
     probs(1.f / Size, Size),
-    apm1{ sh, 0x10000u, 24 }, apm2{ sh, 0x800u, 24 }, apm3{ sh, 0x20000u, 24 },
-    iCtx{ 11, 2 },
+    apm1{ sh, 0x10000u, 24 }, apm2{ sh, 0x800u, 24 }, apm3{ sh, 1024, 24 },
+    iCtx{ 11, 1, 9 },
     top(Size - 1), mid(0), bot(0),
     expected(0)
-  {}
+  {
+    iCtx.reset();
+  }
   virtual ~LstmModel() = default;
   virtual void mix(Mixer& m) = 0;
 };

--- a/lstm/SimdLstmModel.hpp
+++ b/lstm/SimdLstmModel.hpp
@@ -105,10 +105,9 @@ public:
       }
     }
 
-    this->iCtx += 2+y, this->iCtx = (bpos << 8) | this->expected;
-    std::uint32_t mask = 0u, i = 0u;
-    for (std::uint32_t ctx = this->iCtx(); ctx > 0u; mask |= (ctx & 1u) << i, i++, ctx >>= 2);
-    mask |= 1u << i;
+    this->iCtx += y;
+    this->iCtx = (bpos << 8) | this->expected;
+    std::uint32_t ctx = this->iCtx();
 
     int const p = min(max(std::lround(prediction * 4096.0f), 1), 4095);
     m.promote(stretch(p)/2);
@@ -116,7 +115,7 @@ public:
     m.add((p - 2048) >> 2);
     int const pr1 = this->apm1.p(p, (c0 << 8) | (this->shared->State.misses & 0xFF), 0xFF);
     int const pr2 = this->apm2.p(p, (bpos << 8) | this->expected, 0xFF);
-    int const pr3 = this->apm3.p(pr2, mask, 0xFF);
+    int const pr3 = this->apm3.p(pr2, ctx, 0xFF);
     m.add(stretch(pr1) >> 1);
     m.add(stretch(pr2) >> 1);
     m.add(stretch(pr3) >> 1);

--- a/model/ContextModel.cpp
+++ b/model/ContextModel.cpp
@@ -76,10 +76,10 @@ auto ContextModel::p() -> int {
 
   m->add(256); //network bias
 
+  NormalModel& normalModel = models.normalModel();
+  normalModel.mix(*m);
   MatchModel &matchModel = models.matchModel();
   matchModel.mix(*m);
-  NormalModel &normalModel = models.normalModel();
-  normalModel.mix(*m);
   if ((shared->options & OPTION_LSTM) != 0u) {
     LstmModel<>& lstmModel = models.lstmModel();
     lstmModel.mix(*m);

--- a/model/Image8BitModel.cpp
+++ b/model/Image8BitModel.cpp
@@ -24,7 +24,7 @@ Image8BitModel::Image8BitModel(Shared* const sh, const uint64_t size) :
   sceneMap { /* IndirectMap: BitsOfContext, InputBits, Scale, Limit */
     {sh,8,8,64,255}, {sh,8,8,64,255}, {sh,22,1,64,255}, {sh,11,1,64,255}, {sh,11,1,64,255}
   },
-      iCtx {     /* IndirectContext<U8>: BitsPerContext, InputBits */
+  iCtx {     /* IndirectContext<U8>: BitsPerContext, InputBits */
     {16,8}, {16,8}, {16,8}, {16,8}
   }
   {}

--- a/model/MatchModel.hpp
+++ b/model/MatchModel.hpp
@@ -3,6 +3,7 @@
 
 #include "../Shared.hpp"
 #include "../ContextMap2.hpp"
+#include "../HashElementForMatchPositions.hpp"
 #include "../IndirectContext.hpp"
 #include "../LargeStationaryMap.hpp"
 #include "../SmallStationaryContextMap.hpp"
@@ -16,44 +17,187 @@
  */
 class MatchModel {
 private:
-    static constexpr int numHashes = 3;
     static constexpr int nCM = 2;
     static constexpr int nST = 3;
     static constexpr int nLSM = 1;
     static constexpr int nSM = 1;
     Shared * const shared;
-    enum Parameters : uint32_t {
-        MaxExtend = 0, /**< longest allowed match expansion // warning: larger value -> slowdown */
-        MinLen = 5, /**< minimum required match length */
-        StepSize = 2, /**< additional minimum length increase per higher order hash */
-    };
-    Array<uint32_t> table;
+    Array<HashElementForMatchPositions> hashtable;
     StateMap stateMaps[nST];
     ContextMap2 cm;
     LargeStationaryMap mapL[nLSM];
     StationaryMap map[nSM];
+    static constexpr uint32_t iCtxBits = 7;
     IndirectContext<uint8_t> iCtx;
-    uint32_t hashes[numHashes] {0};
     uint32_t ctx[nST] {0};
-    uint32_t length = 0; /**< rebased length of match (length=1 represents the smallest accepted match length), or 0 if no match */
-    uint32_t index = 0; /**< points to next byte of match in buf, 0 when there is no match */
-    uint32_t lengthBak = 0; /**< allows match recovery after a 1-byte mismatch */
-    uint32_t indexBak = 0;
-    uint8_t expectedByte = 0; /**< prediction is based on this byte (buf[index]), valid only when length>0 */
-    bool delta = false; /**< indicates that a match has just failed (delta mode) */
     const int hashBits;
     Ilog *ilog = &Ilog::getInstance();
 
+    static constexpr int MINLEN_RM = 5; //minimum length in recovery mode before we "fully recover"
+    static constexpr int LEN5 = 5;
+    static constexpr int LEN7 = 7;
+    static constexpr int LEN9 = 9;
+
+    struct MatchInfo {
+
+      uint32_t length = 0; /**< rebased length of match (length=1 represents the smallest accepted match length), or 0 if no match */
+      uint32_t index = 0; /**< points to next byte of match in buf, 0 when there is no match */
+      uint32_t lengthBak = 0; /**< allows match recovery after a 1-byte mismatch */
+      uint32_t indexBak = 0;
+      uint8_t expectedByte = 0; /**< prediction is based on this byte (buf[index]), valid only when length>0 */
+      bool delta = false; /**< indicates that a match has just failed (delta mode) */
+
+      bool isInNoMatchMode() {
+        return length == 0 && !delta && lengthBak == 0;
+      }
+
+      bool isInPreRecoveryMode() {
+        return length == 0 && !delta && lengthBak != 0;
+      }
+
+      bool isInRecoveryMode() {
+        return length != 0 && lengthBak != 0;
+      }
+
+      uint32_t recoveryModePos() {
+        assert(isInRecoveryMode()); //must be in recovery mode
+        assert(length - lengthBak <= MINLEN_RM);
+        return length - lengthBak;
+      }
+
+      uint64_t prio() {
+        return
+          static_cast<uint64_t>(length != 0) << 49 | //normal mode (match)
+          static_cast<uint64_t>(delta) << 48 | //delta mode
+          static_cast<uint64_t>(delta ? lengthBak : length) << 32 | //the lnger wins
+          static_cast<uint64_t>(index); //the more recent wins
+      }
+      bool isBetterThan(MatchInfo* other) {
+        return this->prio() > other->prio();
+      }
+
+      void update(Shared* shared) {
+        if constexpr (false) {
+          INJECT_SHARED_bpos
+          INJECT_SHARED_blockPos
+          printf("- pos %d %d  index %d  length %d  lengthBak %d  delta %d\n", blockPos, bpos, index, length, lengthBak, delta ? 1 : 0);
+        }
+        INJECT_SHARED_buf
+        INJECT_SHARED_bpos
+        if (length != 0) {
+          const int expectedBit = (expectedByte >> ((8 - bpos) & 7)) & 1;
+          INJECT_SHARED_y
+          if (y != expectedBit) {
+            if (isInRecoveryMode()) { // another mismatch in recovery mode -> give up
+              lengthBak = 0;
+              indexBak = 0;
+            }
+            else { //backup match information: maybe we can recover it just after this mismatch
+              lengthBak = length;
+              indexBak = index;
+              delta = true; //enter into delta mode - for the remaining bits in this byte length will be 0; we will exit delta mode and enter into recovery mode on bpos==0
+            }
+            length = 0;
+          }
+        }
+
+        if (bpos == 0) {
+
+          // recover match after a 1-byte mismatch
+          if (isInPreRecoveryMode()) { // just exited delta mode, so we have a backup
+            //the match failed 2 bytes ago, we must increase indexBak by 2:
+            indexBak++;
+            if (lengthBak < 65535) {
+              lengthBak++;
+            }
+            INJECT_SHARED_c1
+            if (buf[indexBak] == c1) { // match continues -> recover
+              length = lengthBak;
+              index = indexBak;
+            }
+            else { // still mismatch
+              lengthBak = indexBak = 0; // purge backup (give up)
+            }
+          }
+
+          // extend current match
+          if (length != 0) {
+            index++;
+            if (length < 65535) {
+              length++;
+            }
+            if (isInRecoveryMode() && recoveryModePos() >= MINLEN_RM) { // strong recovery -> exit tecovery mode (finalize)
+              lengthBak = indexBak = 0; // purge backup
+            }
+          }
+          delta = false;
+        }
+        if constexpr(false) {
+          INJECT_SHARED_bpos
+          INJECT_SHARED_blockPos
+          printf("  pos %d %d  index %d  length %d  lengthBak %d  delta %d\n", blockPos, bpos, index, length, lengthBak, delta ? 1 : 0);
+        }
+
+      }
+
+      void registerMatch(const uint32_t pos, const uint32_t LEN) {
+        assert(pos != 0);
+        length = LEN - LEN5 + 1; // rebase
+        index = pos;
+        lengthBak = indexBak = 0;
+        expectedByte = 0;
+        delta = false;
+      }
+
+    };
+
+    bool isMatch(const uint32_t pos, const uint32_t MINLEN) {
+      INJECT_SHARED_buf
+      for (uint32_t length = 1; length <= MINLEN; length++) {
+        if (buf(length) != buf[pos - length])
+          return false;
+      }
+      return true;
+    }
+
+    void AddCandidates(HashElementForMatchPositions* matches, uint32_t LEN) {
+      uint32_t i = 0;
+      INJECT_SHARED_pos
+      while (numberOfActiveCandidates < N && i < HashElementForMatchPositions::N) {
+        uint32_t matchpos = matches->matchPositions[i];
+        if (matchpos == 0)
+          break;
+        if (isMatch(matchpos, LEN)) {
+          bool isSame = false;
+          //is this position already registered?
+          for (uint32_t j = 0; j < numberOfActiveCandidates; j++) {
+            MatchInfo* oldcandidate = &matchCandidates[j];
+            if (isSame = oldcandidate->index == matchpos)
+              break;
+          }
+          if (!isSame) { //don't register an already registered sequence
+            matchCandidates[numberOfActiveCandidates].registerMatch(matchpos, LEN);
+            numberOfActiveCandidates++;
+          }
+        }
+        i++;
+      }
+    }
+
+    static constexpr size_t N = 4;
+    Array<MatchInfo> matchCandidates{ N };
+    uint32_t numberOfActiveCandidates = 0;
+
 public:
     static constexpr int MIXERINPUTS = 
-      2 + // inputs based on expected bit
+      2 + // direct inputs based on expectedBit
       nCM * (ContextMap2::MIXERINPUTS + ContextMap2::MIXERINPUTS_RUN_STATS) + 
       nST * 2 +
       nLSM * LargeStationaryMap::MIXERINPUTS +
       nSM * StationaryMap::MIXERINPUTS; // 24
-    static constexpr int MIXERCONTEXTS = 8;
+    static constexpr int MIXERCONTEXTS = 20;
     static constexpr int MIXERCONTEXTSETS = 1;
-    MatchModel(Shared* const sh, const uint64_t buffermemorysize, const uint64_t mapmemorysize);
+    MatchModel(Shared* const sh, const uint64_t hashtablesize, const uint64_t mapmemorysize);
     void update();
     void mix(Mixer &m);
 };

--- a/model/NormalModel.cpp
+++ b/model/NormalModel.cpp
@@ -10,7 +10,7 @@ NormalModel::NormalModel(Shared* const sh, const uint64_t cmSize) :
 }
 
 void NormalModel::reset() {
-  memset(&cxt[0], 0, sizeof(cxt));
+  memset(&shared->State.cxt[0], 0, sizeof(shared->State.cxt));
 }
 
 void NormalModel::updateHashes() {
@@ -21,6 +21,7 @@ void NormalModel::updateHashes() {
       blockType == AUDIO_LE = AUDIO
       blockType == TEXT_EOL = TEXT
   */
+  uint64_t* cxt = shared->State.cxt;
   for( uint64_t i = 14; i > 0; --i ) {
     cxt[i] = (cxt[i - 1] + blocktype_c1 + i) * PHI64;
   }
@@ -30,6 +31,7 @@ void NormalModel::mix(Mixer &m) {
   INJECT_SHARED_bpos
   if( bpos == 0 ) {
     updateHashes();
+    uint64_t* cxt = shared->State.cxt;
     const uint8_t RH = CM_USE_RUN_STATS | CM_USE_BYTE_HISTORY;
     for(uint64_t i = 1; i <= 7; ++i ) {
       cm.set(RH, cxt[i]);

--- a/model/NormalModel.cpp
+++ b/model/NormalModel.cpp
@@ -33,10 +33,11 @@ void NormalModel::mix(Mixer &m) {
     updateHashes();
     uint64_t* cxt = shared->State.cxt;
     const uint8_t RH = CM_USE_RUN_STATS | CM_USE_BYTE_HISTORY;
-    for(uint64_t i = 1; i <= 7; ++i ) {
+    for(uint64_t i = 1; i <= 6; ++i ) {
       cm.set(RH, cxt[i]);
     }
-    cm.set(RH, cxt[9]);
+    cm.set(RH, cxt[8]); 
+    cm.set(RH, cxt[11]);
     cm.set(RH, cxt[14]);
   }
   cm.mix(m);

--- a/model/NormalModel.hpp
+++ b/model/NormalModel.hpp
@@ -18,7 +18,6 @@ private:
     StateMap smOrder0Slow;
     StateMap smOrder1Slow;
     StateMap smOrder1Fast;
-    uint64_t cxt[15] {}; // context hashes
 public:
     static constexpr int MIXERINPUTS =
             nCM * (ContextMap2::MIXERINPUTS + ContextMap2::MIXERINPUTS_RUN_STATS + ContextMap2::MIXERINPUTS_BYTE_HISTORY) + nSM; //66

--- a/model/SparseBitModel.cpp
+++ b/model/SparseBitModel.cpp
@@ -24,8 +24,8 @@ void SparseBitModel::mix(Mixer &m) {
     }
     cm.set(__, hash(++i, c4 & 0x00f0f0ff));
     cm.set(__, hash(++i, c4 & 0xdfdfdfe0));
-    cm.set(__, hash(++i, c4 & 0xffc0ffc0));
-    cm.set(__, hash(++i, c4 & 0xe0ffffe0));
+    cm.set(__, hash(++i, c4 & 0xffc0ffc0)); //note: silesia/osdb does not like this context
+    cm.set(__, hash(++i, c4 & 0xe0ffffe0)); //note: silesia/osdb does not like this context
     cm.set(__, hash(++i, c4 & 0x00e0e0e0));
     cm.set(__, hash(++i, c4 & 0xe0e0e0e0));
     assert(i == nCM);

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "200"  //update version here before publishing your changes
+#define PROGVERSION  "201"  //update version here before publishing your changes
 #define PROGYEAR     "2020"
 
 
@@ -36,10 +36,10 @@ static void printHelp() {
          "  " PROGNAME " -LEVEL[SWITCHES] INPUTSPEC [OUTPUTSPEC]\n"
          "\n"
          "    -LEVEL:\n"
-         "      -0 = no compression, only transformations when applicable (uses 515 MB)\n"
-         "      -1 -2 -3 = compress using less memory (621, 636, 664 MB)\n"
-         "      -4 -5 -6 -7 -8 -9 = use more memory (720, 833, 1058, 1508, 2409, 4210 MB)\n"
-         "      -10  -11  -12     = use even more memory (7812, 15019, 28404 MB)\n"
+         "      -0 = no compression, only transformations when applicable (uses 517 MB)\n"
+         "      -1 -2 -3 = compress using less memory (623, 637, 665 MB)\n"
+         "      -4 -5 -6 -7 -8 -9 = use more memory (722, 834, 1059, 1509, 2410, 4210 MB)\n"
+         "      -10  -11  -12     = use even more memory (7811, 15013, 28392 MB)\n"
          "    The listed memory requirements are indicative, actual usage may vary\n"
          "    depending on several factors including need for temporary files,\n"
          "    temporary memory needs of some preprocessing (transformations), etc.\n"

--- a/paq8px.vcxproj
+++ b/paq8px.vcxproj
@@ -357,6 +357,7 @@
     <ClInclude Include="filter\TextParserStateInfo.hpp" />
     <ClInclude Include="filter\zlib.hpp" />
     <ClInclude Include="Hash.hpp" />
+    <ClInclude Include="HashElementForMatchPositions.hpp" />
     <ClInclude Include="HashElementForContextMap.hpp" />
     <ClInclude Include="HashElementForStationaryMap.hpp" />
     <ClInclude Include="HashTable.hpp" />

--- a/paq8px.vcxproj.filters
+++ b/paq8px.vcxproj.filters
@@ -650,6 +650,9 @@
     <ClInclude Include="HashElementForStationaryMap.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="HashElementForMatchPositions.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
- IndirectContext improvement: using a leading bit to distinguish context bits from empty (unused) bits
- LSTM model: Applied the new IndirectContext improvements
- MatchModel improvements: 
  - moved context hashes from NormalModel to Shared so MatchModel can also use them
  - using more candidates in hashtable (3 instead of 1)
  - using the improved IndirectContext
  - refined contexts
  - tuned NormalModel contexts wrt MatchModel context lengths