### PR TITLE
paq8px v207fix1: #define wrap changes to allow compilation on ARM platforms.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1987,3 +1987,7 @@ paq8px_v207 by Zoltán Gotthardt
 - Added 2 WordModel (linemodel) contexts targeting structured text files with re-occuring line content such as silesia/nci; Tuned other WordModel (linemodel) contexts; Using the RecordLength as LineLength to boost wordmodel (linemodel) performance for DBase and DEC-Alpha content.
 - Use a separate LSTM model for each main context type.
 - Other cosmetic changes.
+
+paq8px_v2207fix1 by Moisés Cardona
+2022.08.07
+- Fixed compiling paq8px on ARM processors using GCC.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,4 +47,4 @@ endif ()
 #        $<$<CXX_COMPILER_ID:GNU>:
 #        -Wall -Wextra>)
 
-target_link_libraries(paq8px ${ZLIB_LIBRARIES} -static)
+target_link_libraries(paq8px ${ZLIB_LIBRARIES})

--- a/lstm/SimdFunctions.hpp
+++ b/lstm/SimdFunctions.hpp
@@ -12,35 +12,31 @@ namespace {
   * Adapted from https://stackoverflow.com/questions/6996764/fastest-way-to-do-horizontal-sse-vector-sum-or-other-reduction
   */
 
-#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64)
 __attribute__((target("sse3")))
 #endif
+#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 ALWAYS_INLINE float hsum_ps_sse3(__m128 const v) {
-#if !defined(__i386__) && !defined(__x86_64__) && !defined(_M_X64)
-  return 0.f;
-#else
   __m128 shuf = _mm_movehdup_ps(v); // broadcast elements 3,1 to 2,0
   __m128 sums = _mm_add_ps(v, shuf);
   shuf = _mm_movehl_ps(shuf, sums); // high half -> low half
   sums = _mm_add_ss(sums, shuf);
   return _mm_cvtss_f32(sums);
-#endif
 }
+#endif
 
-#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64)
 __attribute__((target("avx")))
 #endif
+#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 ALWAYS_INLINE float hsum256_ps_avx(__m256 const v) {
-#if !defined(__i386__) && !defined(__x86_64__) && !defined(_M_X64)
-  return 0.f;
-#else
   __m128 vlow = _mm256_castps256_ps128(v);
   __m128 vhigh = _mm256_extractf128_ps(v, 1); // high 128
   vlow = _mm_add_ps(vlow, vhigh);     // add the low 128
   return hsum_ps_sse3(vlow);         // and inline the sse3 version, which is optimal for AVX
                                      // (no wasted instructions, and all of them are the 4B minimum)
-#endif
 }
+#endif
 
 #if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("avx2,fma")))

--- a/lstm/SimdFunctions.hpp
+++ b/lstm/SimdFunctions.hpp
@@ -13,9 +13,9 @@ namespace {
   */
 
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64)
+# if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("sse3")))
 #endif
-#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 ALWAYS_INLINE float hsum_ps_sse3(__m128 const v) {
   __m128 shuf = _mm_movehdup_ps(v); // broadcast elements 3,1 to 2,0
   __m128 sums = _mm_add_ps(v, shuf);
@@ -26,9 +26,9 @@ ALWAYS_INLINE float hsum_ps_sse3(__m128 const v) {
 #endif
 
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64)
+# if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 __attribute__((target("avx")))
 #endif
-#if (defined(__GNUC__) || defined(__clang__)) && (!defined(__ARM_FEATURE_SIMD32) && !defined(__ARM_NEON))
 ALWAYS_INLINE float hsum256_ps_avx(__m256 const v) {
   __m128 vlow = _mm256_castps256_ps128(v);
   __m128 vhigh = _mm256_extractf128_ps(v, 1); // high 128

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "207"  //update version here before publishing your changes
+#define PROGVERSION  "207fix1"  //update version here before publishing your changes
 #define PROGYEAR     "2022"
 
 


### PR DESCRIPTION
Functions `hsum_ps_sse3(__m128 const v)` and `hsum256_ps_avx(__m256 const v)` should only be compiled on x86/x64 architecture. ARM compilers do not contain definitions for __m128 and __m256, so I wrapped this to first check the architecture and then if we are compiling using GNUC or Clang.

This follows the same define logic found below for the avx2 and fma attribute on line 94. (`__attribute__((target("avx2,fma")))`)

These changes are also safe since they are only used in this same code below if the architecture is x86/x64.

Tested with GNU 11.3.0 on Ubuntu 22.10 dev. System: ARMv8.

P.S. Named this as v207fix1 since it's only a minor change to allow compilation. Nothing else is done with it.