### PR TITLE
paq8px_v208fix1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2008,3 +2008,9 @@ paq8px_v208 by Zoltán Gotthardt
   - Fixed detection and compilation issue on ARM and unknown platforms (reported by Moisés Cardona)
   - Fixed LargeIndirectContext to work with non-32bit histories.
   - Fixed ContextMap2 behavior when skipping RunStats or ByteHistory contexts.
+
+
+paq8px_v208fix1 by Zoltán Gotthardt
+2023.05.10
+- Cosmetic: Removed unused 'rate' parameter from StationaryMap and LargeStationaryMap.
+- Fixed jpeg model (quantization table parsing).

--- a/LargeStationaryMap.cpp
+++ b/LargeStationaryMap.cpp
@@ -1,18 +1,16 @@
 #include "LargeStationaryMap.hpp"
 
-LargeStationaryMap::LargeStationaryMap(const Shared* const sh, const int contexts, const int hashBits, const int scale, const int rate) :
+LargeStationaryMap::LargeStationaryMap(const Shared* const sh, const int contexts, const int hashBits, const int scale) :
   shared(sh),
   rnd(),
   data((UINT64_C(1) << hashBits)),
   hashBits(hashBits),
   scale(scale),
-  rate(rate),
   numContexts(contexts),
   currentContextIndex(0),
   contextHashes(contexts) {
   assert(hashBits > 0);
   assert(hashBits <= 24); // 24 is just a reasonable limit for memory use 
-  assert(9 <= rate && rate <= 16); // 9 is just a reasonable lower bound, 16 is a hard bound
   reset();
 }
 
@@ -57,7 +55,7 @@ void LargeStationaryMap::update(uint32_t *cp) {
 
   n0 += 1 - y;
   n1 += y;
-  int shift = (n0 | n1) >> rate; // shift: 0 or 1
+  int shift = (n0 | n1) >> 16; // shift: 0 or 1
   n0 >>= shift;
   n1 >>= shift;
 

--- a/LargeStationaryMap.hpp
+++ b/LargeStationaryMap.hpp
@@ -22,7 +22,7 @@ private:
   Random rnd;
   Array<Bucket16<HashElementForStationaryMap, 7>> data;
   const uint32_t hashBits;
-  int scale, rate;
+  int scale;
 
   const uint32_t numContexts; /**< Maximum supported contexts */
   uint32_t currentContextIndex; /**< Number of context indexes present in cxt array (0..numContexts-1) */
@@ -47,9 +47,8 @@ public:
     *      ...              ...                         ...
     * 
     * @param scale
-    * @param rate use 16 near-stationary modelling (default), smaller values may be used for tuning adaptivity
     */
-  LargeStationaryMap(const Shared* const sh, const int contexts, const int hashBits, const int scale = 64, const int rate = 16);
+  LargeStationaryMap(const Shared* const sh, const int contexts, const int hashBits, const int scale = 64);
 
   /**
     * ctx must be a hash

--- a/StationaryMap.cpp
+++ b/StationaryMap.cpp
@@ -1,15 +1,14 @@
 #include "StationaryMap.hpp"
 
-StationaryMap::StationaryMap(const Shared* const sh, const int bitsOfContext, const int inputBits, const int scale, const int rate) : 
+StationaryMap::StationaryMap(const Shared* const sh, const int bitsOfContext, const int inputBits, const int scale) : 
   shared(sh),
   data((UINT64_C(1) << bitsOfContext) * ((UINT64_C(1) << inputBits) - 1)),
   mask((1 << bitsOfContext) - 1), 
-  stride((1 << inputBits) - 1), bTotal(inputBits), scale(scale), rate(rate),
+  stride((1 << inputBits) - 1), bTotal(inputBits), scale(scale),
   context(0), bCount(0), b(0), cp(nullptr)
 {
   assert(inputBits > 0 && inputBits <= 8);
   assert(bitsOfContext + inputBits <= 24);
-  assert(9 <= rate && rate <= 16); // 9 is just a reasonable lower bound, 16 is a hard bound
 }
 
 void StationaryMap::set(uint32_t ctx) {
@@ -19,10 +18,6 @@ void StationaryMap::set(uint32_t ctx) {
 
 void StationaryMap::setScale(int scale) {
   this->scale = scale;
-}
-
-void StationaryMap::setRate(int rate) {
-  this->rate = rate;
 }
 
 void StationaryMap::reset() {
@@ -41,7 +36,7 @@ void StationaryMap::update() {
 
   n0 += 1 - y;
   n1 += y;
-  int shift = (n0 | n1) >> rate; // shift: 0 or 1
+  int shift = (n0 | n1) >> 16; // shift: 0 or 1
   n0 >>= shift;
   n1 >>= shift;
 

--- a/StationaryMap.hpp
+++ b/StationaryMap.hpp
@@ -19,7 +19,7 @@ private:
   const Shared * const shared;
   Array<uint32_t> data;
   const uint32_t mask, stride, bTotal;
-  int scale, rate;
+  int scale;
   uint32_t context;
   uint32_t bCount;
   uint32_t b;
@@ -31,9 +31,8 @@ public:
     * @param bitsOfContext How many bits to use for each context. Higher bits are discarded.
     * @param inputBits How many bits [1..8] of input are to be modelled for each context. New contexts must be set at those intervals.
     * @param scale
-    * @param rate Use 16 for near-stationary modelling (default), smaller values may be used for tuning adaptivity
     */
-  StationaryMap(const Shared* const sh, const int bitsOfContext, const int inputBits, const int scale = 64, const int rate = 16);
+  StationaryMap(const Shared* const sh, const int bitsOfContext, const int inputBits, const int scale = 64);
 
   /**
     * ctx must be a direct context (no hash)
@@ -41,7 +40,6 @@ public:
     */
   void set(uint32_t ctx);
   void setScale(int scale);
-  void setRate(int rate);
   void reset();
   void update() override;
   void mix(Mixer &m);

--- a/model/JpegModel.hpp
+++ b/model/JpegModel.hpp
@@ -141,7 +141,7 @@ private:
 
   //for parsing Quantization tables
   int dqt_state = -1;
-  uint32_t dqtEnd = 0, qNum = 0;
+  uint32_t dqtEnd = 0, qNum = 0, qNum16 = 0, qNum16b = 0;
 
   // context model
   BH<9> t; // context hash -> bit history

--- a/model/SparseMatchModel.cpp
+++ b/model/SparseMatchModel.cpp
@@ -2,7 +2,7 @@
 
 SparseMatchModel::SparseMatchModel(const Shared* const sh, const uint64_t size) : shared(sh), 
   table(size / sizeof(uint32_t)), 
-  mapL {sh,nLSM,17,64,16},  /* LargeStationaryMap: Contexts, HashMaskBits, Scale, AdaptivityRate  */
+  mapL {sh,nLSM,17,64},  /* LargeStationaryMap: Contexts, HashMaskBits, Scale */
   maps{ /* StationaryMap: BitsOfContext, InputBits, Scale=64, Rate=16  */
     {sh,17,4}, {sh,8,1}, {sh,19,1}
   },

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "208"  //update version here before publishing your changes
+#define PROGVERSION  "208fix1"  //update version here before publishing your changes
 #define PROGYEAR     "2023"
 
 


### PR DESCRIPTION
- Cosmetic: Removed unused 'rate' parameter from StationaryMap and LargeStationaryMap.
- Fixed jpeg model (quantization table parsing).
