### PR TITLE
Filters: handle 0 blocksize by early exit

### DIFF
--- a/filter/Filters.hpp
+++ b/filter/Filters.hpp
@@ -2404,6 +2404,8 @@ static uint64_t decompressRecursive(File *out, uint64_t blockSize, Encoder &en, 
   while( i < blockSize ) {
 
     uint64_t len = Block::DecodeBlockHeader(&en);
+    if (len == 0)
+        return 0;
     BlockType type = en.predictorMain.shared->State.blockType;
     int info = en.predictorMain.shared->State.blockInfo;
     if (type == BlockType::MRB) {


### PR DESCRIPTION
When decoding a Block, if the reported len is equal to 0, we currently enter an infinite loop.

Instead of doing that just refuse to decode it and return 0 bytes.