### PR TITLE
paq8px_v214

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2093,3 +2093,13 @@ paq8px_v213 by Zoltán Gotthardt
   - Fixed some typos (thanks Dark1510!)
   - Enhanced build on linux / arch (thanks Dark1510!)
   - Fix ARM64 build (thanks rafael2k!)
+
+
+paq8px_v214 by Zoltán Gotthardt
+2026.04.13
+- Audio8BitModel: use ResidualMap instead of SmallStationaryContextMap.
+- Image24BitModel: 
+  - Use independent mixers per color channel.
+  - Tuned mixer scaling factor and lower limit of learning rate, removed bias.
+  - Use ResidualMap instead of StationaryMap for OLS.
+  - Added and optimized contexts and mixer contexts.

--- a/DummyMixer.hpp
+++ b/DummyMixer.hpp
@@ -13,8 +13,6 @@ public:
   DummyMixer(const Shared* const sh, int n, int m, int s);
   void update() override;
   int p() override;
-  void setScaleFactor(const int /*sf0*/, const int /*sf1*/) override {}
-  void promote(int) override {}
 protected:
   int  dotProduct(const short* /*w*/, const size_t /*n*/) override { return 0; }
   int  dotProduct2(const short* /*w0*/, const short* /*w1*/, const size_t /*n*/, int& sum1) override { sum1 = 0; return 0; }

--- a/HashElementForBitHistoryState.hpp
+++ b/HashElementForBitHistoryState.hpp
@@ -1,9 +1,9 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 #include "StateTable.hpp"
 
-struct HashElementForBitHistoryState { // sizeof(HashElemetForContextMap) = 1
+struct HashElementForBitHistoryState {
   uint8_t bitState;
 
   // priority for hash replacement strategy
@@ -11,3 +11,5 @@ struct HashElementForBitHistoryState { // sizeof(HashElemetForContextMap) = 1
     return StateTable::prio(bitState);
   }
 };
+
+static_assert (sizeof(HashElementForBitHistoryState) == 1);

--- a/HashElementForContextMap.hpp
+++ b/HashElementForContextMap.hpp
@@ -1,9 +1,9 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 #include "StateTable.hpp"
 
-struct HashElementForContextMap { // sizeof(HashElemetForContextMap) = 7
+struct HashElementForContextMap {
   union {
 
     uint8_t states[7];
@@ -37,3 +37,6 @@ struct HashElementForContextMap { // sizeof(HashElemetForContextMap) = 7
     return StateTable::prio(priority);
   }
 };
+
+static_assert (sizeof(HashElementForContextMap) == 7);
+

--- a/HashElementForMatchPositions.hpp
+++ b/HashElementForMatchPositions.hpp
@@ -1,8 +1,8 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 
-struct HashElementForMatchPositions { // sizeof(HashElementForMatchPositions) = 3*4 = 12
+struct HashElementForMatchPositions {
   static constexpr size_t N = 3;
   uint32_t matchPositions[N];
   void Add(uint32_t pos) {
@@ -12,3 +12,5 @@ struct HashElementForMatchPositions { // sizeof(HashElementForMatchPositions) = 
     matchPositions[0] = pos;
   }
 };
+
+static_assert(sizeof(HashElementForMatchPositions) == 3 * 4);

--- a/HashElementForStationaryMap.hpp
+++ b/HashElementForStationaryMap.hpp
@@ -1,8 +1,8 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 
-struct HashElementForStationaryMap { // sizeof(HashElemetForStationaryMap) = 4
+struct HashElementForStationaryMap {
 
   uint32_t value;
 
@@ -12,3 +12,5 @@ struct HashElementForStationaryMap { // sizeof(HashElemetForStationaryMap) = 4
   }
 
 };
+
+static_assert(sizeof(HashElementForStationaryMap) == 4);

--- a/Mixer.cpp
+++ b/Mixer.cpp
@@ -106,6 +106,13 @@ void Mixer::setScaleFactor(const int sf0, const int sf1) {
   }
 }
 
+void Mixer::setLowerLimitOfLearningRate(const int lr0, const int lr1) {
+  lowerLimitOfLearningRate = lr0 * 65536;
+  if (mp != nullptr) {
+    mp->setLowerLimitOfLearningRate(lr1, 0);
+  }
+}
+
 void Mixer::promote(const int x) {
   if (mp != nullptr) {
     mp->add(x);

--- a/Mixer.hpp
+++ b/Mixer.hpp
@@ -23,9 +23,9 @@ protected:
   const size_t n; /**< max inputs */
   const uint32_t m; /**< max contexts */
   const uint32_t s; /**< max context sets */
-  const int lowerLimitOfLearningRate; /**< for linear learning rate decay */
   const bool isAdaptiveLearningRate; /**< linked to command line option '-a' */
   int scaleFactor; /**< scale factor for dot product */
+  int lowerLimitOfLearningRate; /**< for linear learning rate decay */
   Array<short, 64> tx; /**< n inputs from add() */
   Array<short, 64> wx; /**< n*m weights */
   Array<uint32_t> cxt; /**< s contexts */
@@ -91,8 +91,9 @@ public:
     */
   virtual int p();
 
-  virtual void setScaleFactor(int sf0, int sf1);
-  virtual void promote(int x);
+  void setScaleFactor(int sf0, int sf1);
+  void setLowerLimitOfLearningRate(int lr0, int lr1);
+  void promote(int x);
 
   /**
     * Adjusts weights to minimize the coding cost of the last prediction.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Start with a small file – compression takes time.
 Example output (on Windows):
 ```
 c:\>paq8px.exe -8 file.txt
-paq8px archiver v213 (c) 2026, Matt Mahoney et al.
+paq8px archiver v214 (c) 2026, Matt Mahoney et al.
 
-Creating archive file.txt.paq8px213 in single file mode...
+Creating archive file.txt.paq8px214 in single file mode...
 
 Filename: file.txt (111261 bytes)
 Block segmentation:
@@ -46,7 +46,7 @@ Time 16.62 sec, used 2164 MB (2269587029 bytes) of memory
 ```
 
 > [!NOTE]
-> The output archive extension is versioned (e.g., .paq8px213).
+> The output archive extension is versioned (e.g., .paq8px214).
 
 > [!NOTE]
 > You can place the binary anywhere and reference inputs/outputs by path.
@@ -74,14 +74,14 @@ To view available options + detailed help pages, run `paq8px -help`.
 <summary>Click to expand: full <code>paq8px</code> help</summary>
 
 ```
-paq8px archiver v213 (c) 2026, Matt Mahoney et al.
+paq8px archiver v214 (c) 2026, Matt Mahoney et al.
 Free under GPL, http://www.gnu.org/licenses/gpl.txt
 
 Usage:
   to compress       ->   paq8px -LEVEL[FLAGS] [OPTIONS] INPUT [OUTPUT]
-  to decompress     ->   paq8px -d INPUT.paq8px213 [OUTPUT]
-  to test           ->   paq8px -t INPUT.paq8px213 [OUTPUT]
-  to list contents  ->   paq8px -l INPUT.paq8px213
+  to decompress     ->   paq8px -d INPUT.paq8px214 [OUTPUT]
+  to test           ->   paq8px -t INPUT.paq8px214 [OUTPUT]
+  to list contents  ->   paq8px -l INPUT.paq8px214
 
 LEVEL:
   -1 -2 -3 -4          | Compress using less memory (529, 543, 572, 630 MB)
@@ -117,7 +117,7 @@ Misc options:
 Notes:
   INPUT may be FILE, PATH/FILE, or @FILELIST
   OUTPUT is optional: FILE, PATH, PATH/FILE
-  The archive is created in the current folder with .paq8px213 extension if OUTPUT omitted
+  The archive is created in the current folder with .paq8px214 extension if OUTPUT omitted
   FLAGS are case-insensitive and only needed for compression; they may appear in any order
   INPUT must precede OUTPUT; all other OPTIONS may appear anywhere
 
@@ -239,26 +239,26 @@ Detailed Help
 
   -d  Decompress an archive.
       In single-file mode the content is decompressed, the name of the output is the name of the archive without
-      the .paq8px213 extension.
+      the .paq8px214 extension.
       In multi-file mode first the @LISTFILE is extracted then the rest of the files. Any required folders will
       be created recursively, all files will be extracted with their original names.
       If the output file or files already exist they will be overwritten.
 
       Example: to decompress file.txt to the current folder:
-      paq8px -d file.txt.paq8px213
+      paq8px -d file.txt.paq8px214
 
   -t  Test archive contents by decompressing to memory and comparing with the original data on-the-fly.
       If a file fails the test, the first mismatched position will be printed to screen.
 
       Example: to test archive contents:
-      paq8px -t file.txt.paq8px213
+      paq8px -t file.txt.paq8px214
 
   -l  List archive contents.
       Extracts the embedded @FILELIST (if present) and prints it.
       Applicable only to multi-file archives.
 
       Example: to list the file list (when the archive was created using @files):
-      paq8px -l files.paq8px213
+      paq8px -l files.paq8px214
 
 ----------------------------------
  7. INPUT and OUTPUT Specification
@@ -279,7 +279,7 @@ Detailed Help
     For compression:
 
     * If omitted, the archive is created in the current directory.
-      The name of the archive: INPUT + paq8px213 extension appended.
+      The name of the archive: INPUT + paq8px214 extension appended.
     * If a filename is given, it is used as the archive name.
     * If a directory is given, the archive is created inside it.
     * If the archive file already exists, it will be overwritten.
@@ -287,20 +287,20 @@ Detailed Help
     For decompression:
 
     * If an output filename is not provided, the output will be named the same as the archive without
-      the paq8px213 extension.
+      the paq8px214 extension.
     * If a filename is given, it is used as the output name.
     * If a directory is given, the restored file will be created inside it (the directory must exist).
     * If the output file(s) already exist, they will be overwritten.
 
   Examples:
 
-  To create data.txt.paq8px213 in current directory:
+  To create data.txt.paq8px214 in current directory:
   paq8px -8 data.txt
 
-  To create archive.paq8px213 in current directory:
-  paq8px -8 data.txt archive.paq8px213
+  To create archive.paq8px214 in current directory:
+  paq8px -8 data.txt archive.paq8px214
 
-  To create data.txt.paq8px213 in results/ directory:
+  To create data.txt.paq8px214 in results/ directory:
   paq8px -8 data.txt results/
 
 ---------------------------------
@@ -396,7 +396,7 @@ A `paq8px` archive stores one or more files in a highly compressed format.
 
 ### How to recognize it
 
-The file extension reflects the exact `paq8px` version that created it (e.g., `.paq8px213`).  
+The file extension reflects the exact `paq8px` version that created it (e.g., `.paq8px214`).  
 You can also check the header: if the first bytes read "paq8px", it is likely a `paq8px` archive.  
 Exact version information cannot be inferred from the archive content: the archive header does not encode the specific `paq8px` version used. Only the file extension reflects the version.
 
@@ -469,9 +469,9 @@ The following compiler/OS combinations have been tested successfully:
 
 | Version | OS                             | Compiler/IDE                                                  |
 |---------|--------------------------------|---------------------------------------------------------------|
-| v213    | Windows                        | Visual Studio 2022 Community Edition 17.14.14                 |
-| v213    | Windows                        | Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35216   |
-| v213    | Windows                        | MinGW-w64 13.0.0 (gcc-15.2.0)                                 |
+| v214    | Windows                        | Visual Studio 2022 Community Edition 17.14.14                 |
+| v214    | Windows                        | Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35216   |
+| v214    | Windows                        | MinGW-w64 13.0.0 (gcc-15.2.0)                                 |
 | v211    | Lubuntu 25.04 Plucky Puffin    | gcc (Ubuntu 14.2.0-19ubuntu2) 14.2.0                          |
 | v211    | Lubuntu 25.04 Plucky Puffin    | Ubuntu clang version 20.1.2 (0ubuntu1), Target: x86_64-pc-linux-gnu |
 | v211    | Lubuntu 25.04 Plucky Puffin    | aarch64-linux-gnu-gcc (Ubuntu 14.2.0-19ubuntu2) 14.2.0        |
@@ -527,7 +527,7 @@ Summary:
 | Silesia                                          | v213    | #1   |
 | RareWares test samples (16-bit stereo audio)     | v213    | --   |
 | Kodak Lossless True Color Image Suite            | v213    | #1   |
-| ImgInfo RBG test set                             | v213    | #1   |
+| ImgInfo RGB test set                             | v213    | #1   |
 | Lossless Photo Compression Benchmark (LPCB)      | v206    | #1   |
 | Large Text Compression Benchmark (LTCB)          | v206    | #10  |
 | Darek's corpus (DBA)                             | v210    | #1   |
@@ -566,7 +566,7 @@ Below are compressed sizes under various options, compared to `cmix v21` as refe
 With fair options (`-12LT`), `paq8px v210` achieved results close to `cmix v21` (with dictionary pre-processng).  
 With unfair options (`-12RT`), results surpass cmix, but these should be excluded (see [Benchmarking Notes](#benchmarking-notes)).
 
-At the time of writing, `paq8px v213` likely ranks #2 on Calgary behind `cmix v21`.
+At the time of writing, `paq8px v214` likely ranks #2 on Calgary behind `cmix v21`.
 
 ### Canterbury corpus
 
@@ -590,11 +590,11 @@ Below are compressed sizes under various options, compared to `cmix v21`.
 |**Total compressed size**      |**305'337**|**303'634** |**290'559** |**280'310** | **307'705** |  **291'395** |
 |**Compression time (approx. sec)**| **218** |   **645** | **1015** | **1352** | **3354** | **n/a** |
 
-At the time of writing, `paq8px v213` likely ranks #2 on Canterbury behind `cmix v21`.
+At the time of writing, `paq8px v214` likely ranks #2 on Canterbury behind `cmix v21`.
 
 ### Silesia corpus
 
-`paq8px v213` **ranked #1** in [The Silesia Open Source Compression Benchmark](https://mattmahoney.net/dc/silesia.html) at the time of writing.
+`paq8px v210` **ranked #1** in [The Silesia Open Source Compression Benchmark](https://mattmahoney.net/dc/silesia.html) at the time of writing.
 
 Results for `paq8px v213` together with `cmix v21` as reference:
 
@@ -684,36 +684,38 @@ At the time of writing, `paq8px v213` is unranked.
 The [Kodak Lossless True Color Image Suite](https://r0k.us/graphics/kodak/) has no official benchmarking for lossless image compression.
 The images were converted from PNG to PPM before compression.
 
-| File        |(v211)  -8 | (v211) -8L |(v213)  -8 | (v213) -8L |
-|:------------|----------:|-----------:|----------:|-----------:|
-| kodim01.ppm |   322'743 |    318'033 |   315'510 |    312'246 |
-| kodim02.ppm |   266'212 |    262'726 |   257'732 |    255'672 |
-| kodim03.ppm |   208'063 |    206'330 |   201'093 |    199'991 |
-| kodim04.ppm |   273'983 |    270'569 |   267'012 |    264'499 |
-| kodim05.ppm |   350'224 |    345'048 |   339'543 |    335'871 |
-| kodim06.ppm |   296'388 |    292'696 |   290'075 |    287'476 |
-| kodim07.ppm |   229'395 |    226'944 |   222'406 |    220'656 |
-| kodim08.ppm |   361'408 |    355'403 |   353'115 |    348'643 |
-| kodim09.ppm |   252'594 |    250'051 |   245'384 |    243'749 |
-| kodim10.ppm |   259'685 |    257'040 |   252'837 |    251'080 |
-| kodim11.ppm |   285'699 |    282'074 |   279'161 |    276'482 |
-| kodim12.ppm |   238'039 |    235'167 |   231'887 |    230'026 |
-| kodim13.ppm |   406'000 |    398'454 |   398'692 |    392'799 |
-| kodim14.ppm |   321'954 |    318'182 |   313'938 |    311'208 |
-| kodim15.ppm |   260'866 |    257'842 |   253'281 |    251'250 |
-| kodim16.ppm |   243'852 |    241'137 |   238'022 |    236'228 |
-| kodim17.ppm |   259'714 |    257'286 |   252'459 |    250'915 |
-| kodim18.ppm |   371'378 |    364'566 |   362'678 |    357'394 |
-| kodim19.ppm |   299'803 |    296'129 |   293'100 |    290'411 |
-| kodim20.ppm |   243'599 |    241'381 |   239'030 |    237'359 |
-| kodim21.ppm |   304'384 |    300'814 |   297'485 |    294'970 |
-| kodim22.ppm |   337'390 |    331'449 |   329'634 |    325'054 |
-| kodim23.ppm |   258'592 |    255'585 |   249'698 |    247'729 |
-| kodim24.ppm |   306'685 |    301'034 |   298'519 |    294'247 |
-|**Total compressed size**         | **6'958'650** | **6'865'940** | **6'782'291** | **6'715'955** |
-|**Compression time (approx. sec)**|   **1125**   | **5121**     |   **1'750**   | **6'012**     |
+Results for `paq8px v213` and `paq8px v214`:
 
-At the time of writing, `paq8px v213` likely ranks #1 on the Kodak test set among lossless compressors with no pre-trained models.
+| File        |(v213)  -8 | (v213) -8L |(v214)  -8 | (v214) -8L |
+|:------------|----------:|-----------:|----------:|-----------:|
+| kodim01.ppm |   315'510 |    312'246 |   311'386 |    308'621 |
+| kodim02.ppm |   257'732 |    255'672 |   254'005 |    252'320 |
+| kodim03.ppm |   201'093 |    199'991 |   198'223 |    197'404 |
+| kodim04.ppm |   267'012 |    264'499 |   262'669 |    260'569 |
+| kodim05.ppm |   339'543 |    335'871 |   332'641 |    329'738 |
+| kodim06.ppm |   290'075 |    287'476 |   286'119 |    283'942 |
+| kodim07.ppm |   222'406 |    220'656 |   218'511 |    217'107 |
+| kodim08.ppm |   353'115 |    348'643 |   346'164 |    342'504 |
+| kodim09.ppm |   245'384 |    243'749 |   241'422 |    240'025 |
+| kodim10.ppm |   252'837 |    251'080 |   248'722 |    247'300 |
+| kodim11.ppm |   279'161 |    276'482 |   274'932 |    272'722 |
+| kodim12.ppm |   231'887 |    230'026 |   228'755 |    227'222 |
+| kodim13.ppm |   398'692 |    392'799 |   391'737 |    386'548 |
+| kodim14.ppm |   313'938 |    311'208 |   308'775 |    306'562 |
+| kodim15.ppm |   253'281 |    251'250 |   249'470 |    247'873 |
+| kodim16.ppm |   238'022 |    236'228 |   234'886 |    233'322 |
+| kodim17.ppm |   252'459 |    250'915 |   248'414 |    247'115 |
+| kodim18.ppm |   362'678 |    357'394 |   354'562 |    349'938 |
+| kodim19.ppm |   293'100 |    290'411 |   287'755 |    285'541 |
+| kodim20.ppm |   239'030 |    237'359 |   235'864 |    234'483 |
+| kodim21.ppm |   297'485 |    294'970 |   292'545 |    290'341 |
+| kodim22.ppm |   329'634 |    325'054 |   322'563 |    318'509 |
+| kodim23.ppm |   249'698 |    247'729 |   245'520 |    243'895 |
+| kodim24.ppm |   298'519 |    294'247 |   293'309 |    289'773 |
+|**Total compressed size**         | **6'782'291** | **6'715'955** | **6'668'949** | **6'613'374** |
+|**Compression time (approx. sec)**|   **1'750**   | **6'012**     |   **2'007**   | **6'330**     |
+
+At the time of writing, `paq8px v214` likely ranks #1 on the Kodak test set among lossless compressors with no pre-trained models.
 
 Other compressors for reference:
 [GitHub - WangXuan95/Image-Compression-Benchmark: A comparison of many lossless image compression formats.](https://github.com/WangXuan95/Image-Compression-Benchmark?tab=readme-ov-file#kodak-rgb-24-images-28-mb)
@@ -723,26 +725,29 @@ Other compressors for reference:
 
 The [ImgInfo RGB test set](https://imagecompression.info/test_images/) has no official benchmarking for lossless image compression.
 
-| File                   |(v212)   -8L | (v213)  -8L |
-|:-----------------------|------------:|------------:|
-| artificial.ppm         |     410'951 |     396'742 |
-| big_building.ppm       |  43'766'117 |  43'524'971 |
-| big_tree.ppm           |  37'558'061 |  37'369'579 |
-| bridge.ppm             |  16'856'686 |  16'824'955 |
-| cathedral.ppm          |   6'608'112 |   6'576'508 |
-| deer.ppm               |  18'171'712 |  18'168'804 |
-| fireworks.ppm          |   3'191'162 |   3'169'176 |
-| flower_foveon.ppm      |   1'634'155 |   1'621'443 |
-| hdr.ppm                |   4'642'150 |   4'621'868 |
-| leaves_iso_1600.ppm    |   8'249'813 |   8'194'684 |
-| leaves_iso_200.ppm     |   6'376'225 |   6'327'733 |
-| nightshot_iso_100.ppm  |   4'583'696 |   4'558'484 |
-| nightshot_iso_1600.ppm |   9'300'779 |   9'268'001 |
-| spider_web.ppm         |   5'498'493 |   5'492'330 |
-|**Total compressed size**         | **166'848'112** | **166'115'278** |
-|**Compression time (approx. sec)**|   **n.a.**   | **112'768**     |
+Results for `paq8px v213` and `paq8px v214`:
 
-At the time of writing, `paq8px v213` likely ranks #1 on the ImgInfo RGB test set among lossless compressors with no pre-trained models.
+| File                   | (v213)  -8L |(v214)   -8L |
+|:-----------------------|------------:|------------:|
+| artificial.ppm         |     396'742 |     394'150 |
+| big_building.ppm       |  43'524'971 |  42'805'256 |
+| big_tree.ppm           |  37'369'579 |  36'668'068 |
+| bridge.ppm             |  16'824'955 |  16'805'572 |
+| cathedral.ppm          |   6'576'508 |   6'468'273 |
+| deer.ppm               |  18'168'804 |  18'110'156 |
+| fireworks.ppm          |   3'169'176 |   3'129'441 |
+| flower_foveon.ppm      |   1'621'443 |   1'613'759 |
+| hdr.ppm                |   4'621'868 |   4'602'334 |
+| leaves_iso_1600.ppm    |   8'194'684 |   8'034'152 |
+| leaves_iso_200.ppm     |   6'327'733 |   6'212'126 |
+| nightshot_iso_100.ppm  |   4'558'484 |   4'477'648 |
+| nightshot_iso_1600.ppm |   9'268'001 |   9'139'073 |
+| spider_web.ppm         |   5'492'330 |   5'413'843 |
+|**Total compressed size**         | **166'115'278** | **163'873'851** | 
+|**Compression time (approx. sec)**|   **n.a.**   | **111'420**     |
+
+
+At the time of writing, `paq8px v214` likely ranks #1 on the ImgInfo RGB test set among lossless compressors with no pre-trained models.
 
 Other compressors for reference:
 [GitHub - WangXuan95/Image-Compression-Benchmark: A comparison of many lossless image compression formats.](https://github.com/WangXuan95/Image-Compression-Benchmark?tab=readme-ov-file#imginforgb-rgb-14-images-470-mb)
@@ -792,11 +797,11 @@ Compressed sizes for v210 and v213 with compression option `-12L` (`-12Ls` for r
 |**Total compressed size**  | **5'824'680** | **5'794'110** | **-30570** |
 |**Compression time (sec)**| **19'384** |**19'048'** | **-335** |
 
-To the best of our knowledge, `paq8px`'s latest version, `v213`, would still **rank #1** at the time of writing.
+To the best of our knowledge, `paq8px`'s latest version, `v214`, would still **rank #1** at the time of writing.
 
 ### fenwik9 benchmark
 
-`paq8px v210` **ranks #1** in the [fenwik9 benchmark](https://encode.su/threads/3873-fenwik9-benchmark-results).  
+`paq8px v210` **ranked #1** in the [fenwik9 benchmark](https://encode.su/threads/3873-fenwik9-benchmark-results).  
 This is a non-standard but exhaustive single-file benchmark maintained by Sportman.
 
 ### World English Bible benchmark (WEB)
@@ -838,7 +843,7 @@ The table below highlights milestones, contributors, and notable changes over th
 | **2022**     | v207       | **Zoltán Gotthardt**: PNG filtering moved to transform layer; DEC-Alpha detection via object signature; TAR detection/transform; base85 filter (from paq8pxd); structured-text WordModel (linemodel) enhancements; separate LSTM per main context. |
 | **2023**     | v208       | **Zoltán Gotthardt**: TAR detection fixes; new -forcetext option; enhanced 1-bit image model; shifted contexts (fewer in IndirectModel, added to WordModel for TEXT); refactors; Pavel Rosický: AVX512 detection. |
 | **2025**     | v209       | **Zoltán Gotthardt**: Model tweaks (initialized mixer weights; corrected matchmodel context); TEXT detection fixes; build/toolchain updates. |
-| **2026**     | v210-v213  | **Zoltán Gotthardt**: LSTM model enhancements, speed improvements, tuned Audio16BitModel, enhanced 24/32-bit image model. |
+| **2026**     | v210-v214  | **Zoltán Gotthardt**: LSTM model enhancements, speed improvements, tuned Audio16BitModel, enhanced 24/32-bit image model. |
 
 This timeline is not exhaustive, for details, see [CHANGELOG](CHANGELOG).
 
@@ -864,7 +869,7 @@ This timeline is not exhaustive, for details, see [CHANGELOG](CHANGELOG).
 
 ## Similar compressors
 
-- [paq8pdx](https://github.com/kaitz/paq8pxd) by Kaido Orav
+- [paq8pxd](https://github.com/kaitz/paq8pxd) by Kaido Orav
 - [cmix](https://www.byronknoll.com/cmix.html) by Byron Knoll
 
 ## Copyright

--- a/ResidualMap.cpp
+++ b/ResidualMap.cpp
@@ -36,7 +36,7 @@ void ResidualMap::mix(Mixer& m) {
       shared->GetUpdateBroadcaster()->subscribe(this);
   assert(currentContextIndex == numContexts);
 
-  for (size_t i = 0; i < numContexts; i++) {
+  for (size_t i = 0; i < currentContextIndex; i++) {
     const uint32_t base = bases[i];
     if (base == UINT32_MAX) { // skipped context
       m.add(0);

--- a/SSE.cpp
+++ b/SSE.cpp
@@ -75,7 +75,6 @@ uint32_t SSE::p(const uint32_t pr_orig) {
 
   assert(shared->State.Image.plane <= 3);
   assert(shared->State.Image.lossQ <= 639);
-  assert(shared->State.loss <= 255);
 
   //uint32_t misses4 = shared->State.misses & 15u;
   uint32_t misses = shared->State.misses << ((8 - bpos) & 7); //byte-aligned

--- a/Shared.cpp
+++ b/Shared.cpp
@@ -51,11 +51,11 @@ void Shared::update(int y, uint32_t p, bool isMissed) {
   
   State.misses = (State.misses << 1) | static_cast<uint32_t>(isMissed);
 
-  constexpr uint32_t shift = ArithmeticEncoder::PRECISION - 8;
+  constexpr uint32_t shift = ArithmeticEncoder::PRECISION - 6;
   constexpr uint32_t maxp = (1u << ArithmeticEncoder::PRECISION) - 1;
 
-  State.loss = ((y == 0 ? p : maxp - p)) >> shift; //0..255
-  assert(State.loss >= 0 && State.loss <= 255);
+  State.loss = ((y == 0 ? p : maxp - p)) >> shift; //0..1023
+  assert(State.loss >= 0 && State.loss <= 1023);
 
   // Broadcast to all current subscribers: y (and c0, c1, c4, etc) is known
   updateBroadcaster.broadcastUpdate();

--- a/filter/bmp.hpp
+++ b/filter/bmp.hpp
@@ -33,7 +33,7 @@ public:
 
   void encode(File *in, File *out, uint64_t size, int width, int & /*headerSize*/) override {
     uint32_t r = 0;
-    uint32_t g = 0;
+    uint32_t g = 0; // green is always the middle channel in both RGB and BGR images, the transform is symmetric in r and b
     uint32_t b = 0;
     for( int i = 0; i < static_cast<int>(size / width); i++ ) {
       for( int j = 0; j < width / stride; j++ ) {
@@ -52,9 +52,13 @@ public:
           }
           isPossibleRgb565 = rgb565Run > 0;
         }
+        if (!skipRgb) {
+          r = g - r;
+          b = g - b;
+        }
         out->putChar(g);
-        out->putChar(skipRgb ? r : g - r);
-        out->putChar(skipRgb ? b : g - b);
+        out->putChar(r);
+        out->putChar(b);
         if (stride == 4) {
           out->putChar(in->getchar());
         }
@@ -84,7 +88,8 @@ public:
           a = encoder->decompressByte(encoder->predictorMain);
         }
         if( !skipRgb ) {
-          r = g - r, b = g - b;
+          r = g - r;
+          b = g - b;
         }
         if( isPossibleRgb565 ) {
           if( rgb565Run >= rgb565MinRun ) {

--- a/model/Audio8BitModel.cpp
+++ b/model/Audio8BitModel.cpp
@@ -2,12 +2,12 @@
 #include "../BitCount.hpp"
 
 Audio8BitModel::Audio8BitModel(Shared* const sh) : AudioModel(sh),
-sMap1B{ /* SmallStationaryContextMap : BitsOfContext, InputBits, Rate, Scale */
-  /*nOLS: 0-3*/ {{sh,11,1,6,128}, {sh,11,1,9,128}, {sh,11,1,7,86}}, {{sh,11,1,6,128}, {sh,11,1,9,128}, {sh,11,1,7,86}}, {{sh,11,1,6,128}, {sh,11,1,9,128}, {sh,11,1,7,86}}, {{sh,11,1,6,86}, {sh,11,1,9,86}, {sh,11,1,7,86}},
-  /*nOLS: 4-7*/ {{sh,11,1,6,128}, {sh,11,1,9,128}, {sh,11,1,7,86}}, {{sh,11,1,6,128}, {sh,11,1,9,128}, {sh,11,1,7,86}}, {{sh,11,1,6,128}, {sh,11,1,9,128}, {sh,11,1,7,86}}, {{sh,11,1,6,128}, {sh,11,1,9,128}, {sh,11,1,7,86}},
-  /*nLMS: 0-2*/ {{sh,11,1,6,86}, {sh,11,1,9,86}, {sh,11,1,7,86}}, {{sh,11,1,6,86}, {sh,11,1,9,86}, {sh,11,1,7,86}}, {{sh,11,1,6,86}, {sh,11,1,9,86}, {sh,11,1,7,86}},
-  /*nSSM: 0-2*/ {{sh,11,1,6,86}, {sh,11,1,9,86}, {sh,11,1,7,86}}, {{sh,11,1,6,86}, {sh,11,1,9,86}, {sh,11,1,7,86}}, {{sh,11,1,6,86}, {sh,11,1,9,86}, {sh,11,1,7,86}}
-} {
+/* ResidualMap: numContexts, histogramsPerContext, scale=64 */
+  mapR1{ sh, nSSM, 1 << 6, 64 }, 
+  mapR2{ sh, nSSM, 1 << 6, 64 },
+  mapR3{ sh, nSSM, 1 << 6, 96 },
+  mapR4{ sh, nSSM, 1 << 6, 96 }
+{
   /* s, d, sameChannelRate, otherChannelRate */
   lms[0][0] = LMS::create(sh->chosenSimd, 1280, 640, 3e-5f, 2e-5f);
   lms[0][1] = LMS::create(sh->chosenSimd, 1280, 640, 3e-5f, 2e-5f);
@@ -42,10 +42,29 @@ void Audio8BitModel::mix(Mixer &m) {
   INJECT_SHARED_bpos
   INJECT_SHARED_blockPos
   INJECT_SHARED_c1
+
+  loss += shared->State.loss; // += 0..255
+
   if( bpos == 0 ) {
+
     ch = (stereo) != 0 ? blockPos & 1 : 0;
     const int8_t s = static_cast<int32_t>(((wMode & 4) > 0) ? c1 ^ 128 : c1) - 128;
     const int pCh = ch ^ stereo;
+
+    for (int i = 0; i < nSSM; i++) {
+      int prediction0 = prd[i][pCh][0] + 128;
+      uint8_t err0 = abs(c1 - prediction0); // 0..255
+      predErrBuf0[i] = ((predErrBuf0[i] * 15) >> 4) + err0; // -> 4065
+
+      int prediction1 = prd[i][pCh][1] + 128;
+      uint8_t err1 = abs(c1 - prediction1); // 0..255
+      predErrBuf1[i] = ((predErrBuf1[i] * 15) >> 4) + err1; // -> 4065
+    }
+
+    lossQ = (lossQ * 15) >> 4;
+    lossQ += loss;  // +0..2040 -> max: 32625, typical: ~ 4000s
+    loss = 0;
+
     int i = 0;
     for( errLog = 0; i < nOLS; i++ ) {
       ols[i][pCh].get()->update(s);
@@ -150,18 +169,24 @@ void Audio8BitModel::mix(Mixer &m) {
     for( i = 0; i < nSSM; i++ ) {
       prd[i][ch][1] = signedClip8(prd[i][ch][0] + residuals[i][pCh]);
     }
+
+    auto lossQ5bit = min(lossQ / 384, 31);
+    for (int i = 0; i < nSSM; i++) {
+      mapR1.set(prd[i][ch][0] + 128, lossQ5bit << 1 | ch);
+      mapR2.set(prd[i][ch][1] + 128, lossQ5bit << 1 | ch);
+      mapR3.set(prd[i][ch][0] + 128, min(predErrBuf0[i] >> 4, 31) << 1 | ch);
+      mapR4.set(prd[i][ch][1] + 128, min(predErrBuf1[i] >> 4, 31) << 1 | ch);
+    }
   }
+
+  // for every bit
+
+  mapR1.mix(m);
+  mapR2.mix(m);
+  mapR3.mix(m);
+  mapR4.mix(m);
+
   INJECT_SHARED_c0
-  const int8_t b = c0 << (8 - bpos);
-  for( int i = 0; i < nSSM; i++ ) {
-    const uint32_t ctx = (prd[i][ch][0] - b) * 8 + bpos;
-    sMap1B[i][0].set(ctx);
-    sMap1B[i][1].set(ctx);
-    sMap1B[i][2].set((prd[i][ch][1] - b) * 8 + bpos);
-    sMap1B[i][0].mix(m);
-    sMap1B[i][1].mix(m);
-    sMap1B[i][2].mix(m);
-  }
   m.set((errLog << 8) | c0, 4096);
   m.set((uint8_t(mask) << 3) | (ch << 2) | (bpos >> 1), 2048);
   m.set((mxCtx << 7) | (c1 >> 1), 1280);

--- a/model/Audio8BitModel.hpp
+++ b/model/Audio8BitModel.hpp
@@ -4,7 +4,7 @@
 #include "../Ilog.hpp"
 #include "../LMS.hpp"
 #include "../OLS_factory.hpp"
-#include "../SmallStationaryContextMap.hpp"
+#include "../ResidualMap.hpp"
 #include <cmath>
 #include <cstdint>
 
@@ -13,8 +13,19 @@ private:
   static constexpr int nOLS = 8;
   static constexpr int nLMS = 3;
   static constexpr int nSSM = nOLS + nLMS + 3;
-  static constexpr int nCtx = 3;
-  SmallStationaryContextMap sMap1B[nSSM][nCtx];
+  static constexpr int nCtx = 4; //mapR1..mapR4
+
+  ResidualMap mapR1;
+  ResidualMap mapR2;
+  ResidualMap mapR3;
+  ResidualMap mapR4;
+
+  uint32_t loss = 255; // decoding cost for the current byte, accumulated bit by bit (0..255 over 8 bits)
+  uint32_t lossQ = 0; // exponential average of loss
+  // measures local audio complexity: low = smooth region, high = noisy/detailed region
+
+  int predErrBuf0[nSSM]{};
+  int predErrBuf1[nSSM]{};
 
   std::unique_ptr<LMS> lms[nLMS][2]; // 2: channels
 
@@ -32,7 +43,7 @@ private:
   uint32_t mxCtx = 0;
 
 public:
-  static constexpr int MIXERINPUTS = nCtx * nSSM * SmallStationaryContextMap::MIXERINPUTS; // 84
+  static constexpr int MIXERINPUTS = nCtx * nSSM * ResidualMap::MIXERINPUTS; // 112
   static constexpr int MIXERCONTEXTS = 4096 + 2048 + 2048 + 256 + 10; // 8458
   static constexpr int MIXERCONTEXTSETS = 5;
 

--- a/model/ContextModelImage24.cpp
+++ b/model/ContextModelImage24.cpp
@@ -1,46 +1,62 @@
 ﻿#include "../MixerFactory.hpp"
 #include "../Models.hpp"
 
-class ContextModelImage24 : public IContextModel {
+class ContextModelImage24 : public IContextModel
+{
 
 private:
   Shared* const shared;
   Models* const models;
-  Mixer* m;
+  Mixer* m0;
+  Mixer* m1;
+  Mixer* m2;
 
 public:
   ContextModelImage24(Shared* const sh, Models* const models, const MixerFactory* const mf) : shared(sh), models(models) {
     const bool useLSTM = shared->GetOptionUseLSTM();
-    m = mf->createMixer (
-      1 +  //bias
-      MatchModel::MIXERINPUTS + NormalModel::MIXERINPUTS + 
+
+    int mixerinputs =
+      MatchModel::MIXERINPUTS + NormalModel::MIXERINPUTS +
       Image24BitModel::MIXERINPUTS +
-      (useLSTM ? LstmModelContainer::MIXERINPUTS : 0)
-      ,
+      (useLSTM ? LstmModelContainer::MIXERINPUTS : 0);
+    int mixerContexts =
       MatchModel::MIXERCONTEXTS + NormalModel::MIXERCONTEXTS_PRE +
       Image24BitModel::MIXERCONTEXTS +
-      (useLSTM ? LstmModelContainer::MIXERCONTEXTS : 0)
-      ,
-      MatchModel::MIXERCONTEXTSETS + NormalModel::MIXERCONTEXTSETS_PRE + 
+      (useLSTM ? LstmModelContainer::MIXERCONTEXTS : 0);
+    int mixerContextSets =
+      MatchModel::MIXERCONTEXTSETS + NormalModel::MIXERCONTEXTSETS_PRE +
       Image24BitModel::MIXERCONTEXTSETS +
-      (useLSTM ? LstmModelContainer::MIXERCONTEXTSETS : 0)
-      ,
-      (useLSTM ? 1 : 0)
-    );
+      (useLSTM ? LstmModelContainer::MIXERCONTEXTSETS : 0);
+    int promotedInputs = (useLSTM ? 1 : 0);
+
+    m0 = mf->createMixer(mixerinputs, mixerContexts, mixerContextSets, promotedInputs);
+    m1 = mf->createMixer(mixerinputs, mixerContexts, mixerContextSets, promotedInputs);
+    m2 = mf->createMixer(mixerinputs, mixerContexts, mixerContextSets, promotedInputs);
+
+    m0->setScaleFactor(490, 130);
+    m1->setScaleFactor(620, 135);
+    m2->setScaleFactor(770, 140);
+
+    m0->setLowerLimitOfLearningRate(5, 1);
+    m1->setLowerLimitOfLearningRate(5, 1);
+    m2->setLowerLimitOfLearningRate(5, 1);
   }
 
   void setParam(int width, int isAlpha) {
     Image24BitModel& image24BitModel = models->image24BitModel();
     image24BitModel.setParam(width, isAlpha);
-    if (isAlpha)
-      m->setScaleFactor(2048, 128);
-    else
-      m->setScaleFactor(1024, 100); // 800-1300, 90-110
   }
 
   int p() {
 
-    m->add(256); //network bias
+    Image24BitModel& image24BitModel = models->image24BitModel();
+    image24BitModel.update();
+
+    int color = image24BitModel.color;
+    Mixer* m =
+      color == 0 ? m0 :
+      color == 1 ? m1 :
+      color == 2 ? m2 : m2;
 
     NormalModel& normalModel = models->normalModel();
     normalModel.mix(*m);
@@ -54,14 +70,15 @@ public:
       lstmModel.mix(*m);
     }
 
-    Image24BitModel& image24BitModel = models->image24BitModel();
     image24BitModel.mix(*m);
 
     return m->p();
   }
 
   ~ContextModelImage24() {
-    delete m;
+    delete m0;
+    delete m1;
+    delete m2;
   }
 
 };

--- a/model/Image24BitModel.cpp
+++ b/model/Image24BitModel.cpp
@@ -5,11 +5,10 @@ Image24BitModel::Image24BitModel(Shared* const sh, const uint64_t size) :
   cm(sh, size, nCM, 64),
   mapL{ sh, nLSM, 23, 74 },     /* LargeStationaryMap : Contexts, HashBits, Scale=64, Rate=16 */
   mapR1{ sh, nDM, 1 << 7, 74 }, /* ResidualMap: numContexts, histogramsPerContext, scale=64 */
-  mapR2{ sh, nDM, 1 << 7, 74 }, /* ResidualMap: numContexts, histogramsPerContext, scale=64 */
+  mapR2{ sh, nDM, 1 << 5, 74 }, /* ResidualMap: numContexts, histogramsPerContext, scale=64 */
   mapR3{ sh, nDM, 1 << 7, 74 }, /* ResidualMap: numContexts, histogramsPerContext, scale=64 */
-  map{ /* StationaryMap : BitsOfContext, InputBits, Scale=64, Rate=16  */
-    /*nOLS: 0- 5*/ {sh,11,1,74}, {sh,11,1,74}, {sh,11,1,74}, {sh,11,1,74}, {sh,11,1,74}, {sh,11,1,74}
-  }
+  mapOLS1{ sh, nOLS, 1 << 7, 74 },  /* ResidualMap: numContexts, histogramsPerContext, scale=64 */
+  mapOLS2{ sh, nOLS, 1 << 5, 74 }   /* ResidualMap: numContexts, histogramsPerContext, scale=64 */
 {
   for (int i = 0; i < nOLS; i++) {
     for (int j = 0; j < 4; j++) { // RGBA color components
@@ -54,7 +53,8 @@ ALWAYS_INLINE uint8_t Image24BitModel::Ls(int relX, int relY) const {
   if (x - relX >= w)
     return 255;
   int offset = relY * w + relX;
-  return lossBuf(offset);
+  const uint32_t valuesPerByte = 1;
+  return lossBuf((offset - 1) * valuesPerByte + 1);
 }
 
 ALWAYS_INLINE uint8_t Image24BitModel::GetPredErr(const uint32_t ctxIndex, int relX, int relY) const {
@@ -65,12 +65,42 @@ ALWAYS_INLINE uint8_t Image24BitModel::GetPredErr(const uint32_t ctxIndex, int r
     return 255;
   if (x - relX >= w)
     return 255;
-  int offset = relY * w + relX - 1;
-  return predErrBuf(offset * nDM + ctxIndex + 1);
+  int offset = relY * w + relX;
+  const uint32_t valuesPerByte = (nDM + nOLS);
+  return predErrBuf((offset - 1) * valuesPerByte + ctxIndex + 1);
 }
 
-ALWAYS_INLINE int avg(int x, int y) {
+ALWAYS_INLINE uint32_t Image24BitModel::GetPredErrAvg(const uint32_t predictorIndex) const {
+  // Current pixel's prediction confidence is based on the already known error at neighboring pixel predictions
+  uint32_t predErrW = GetPredErr(predictorIndex, 1, 0);
+  uint32_t predErrN = GetPredErr(predictorIndex, 0, 1);
+  uint32_t predErrNW = GetPredErr(predictorIndex, 1, 1);
+  uint32_t predErrNE = GetPredErr(predictorIndex, -1, 1);
+  uint32_t predErrWW = GetPredErr(predictorIndex, 2, 0);
+  uint32_t predErrNN = GetPredErr(predictorIndex, 0, 2);
+  uint32_t predErrAvg = (2 * predErrW + 2 * predErrN + predErrNE + predErrNW + predErrWW + predErrNN) >> 3; // 0..255
+  return predErrAvg;
+}
+
+
+ALWAYS_INLINE static int avg(int x, int y) {
   return (x + y + 1) >> 1;  //note: rounding here works properly only when x+y is non-negative, but we don't really need the function to be aware of negative values as they are rare
+}
+
+// abs(int8_t((c1 - prediction) & 255)): circular/wraparound distance on a 256-value ring
+// int8_t cast recovers the sign from the modular difference, and abs then makes it symmetric.
+// that is:
+// (10 - 3) & 255 = 7   → int8_t(7)   = 7  → abs = 7
+// (3 - 10) & 255 = 249 → int8_t(249) = -7 → abs = 7
+// however with a large distance:
+// (2 - 200) & 255 = 58  → int8_t(58)  = 58  → abs = 58
+// (200 - 2) & 255 = 198 → int8_t(198) = -58 → abs = 58
+// ... but the true linear distance is 198. Distances above 128 are thus
+// reflected back — (200-2) and (2-200) both return 58 instead of 58 and 198.
+// This ambiguity for large differences has negligible impact compared to
+// the cost of using uint16_t to store the full 0..255 range.
+ALWAYS_INLINE static int rabs(int x1, int x2) {
+  return abs(int8_t((x1 - x2) & 255)); // 0..128
 }
 
 // Stores a prediction with a spread signal based on the distance between two reference pixels.
@@ -79,30 +109,36 @@ ALWAYS_INLINE int avg(int x, int y) {
 // Use when the prediction value is computed externally (e.g. a complex algebraic expression)
 // but a natural pair of reference pixels still exists to supply the spread signal.
 ALWAYS_INLINE void Image24BitModel::MakePrediction(int i, uint8_t ref1, uint8_t ref2, int prediction) {
-  uint32_t absdiff = abs(ref1 - ref2);
+  uint32_t absdiff = rabs(ref1, ref2);
   predictions[i] = absdiff << 16 | ((prediction) & 65535);
 }
 
 // Trend extrapolation: continues the gradient observed from pxFar to px,
 // starting from the spatial origin.
 // prediction = origin + (px - pxFar)
-// spread = abs(px - pxFar): larger gradient = more uncertain prediction.
+// spread = rabs(px - pxFar): larger gradient = more uncertain prediction.
 // Use when pixels are expected to follow a consistent directional trend
 // (e.g. continuing a horizontal, vertical, or diagonal gradient).
 ALWAYS_INLINE void Image24BitModel::MakePredictionTrend(int i, int px, int pxFar, int origin) {
-  uint32_t absdiff = abs(px - pxFar);
+  uint32_t absdiff = rabs(px, pxFar);
   int prediction = origin + px - pxFar;
   predictions[i] = absdiff << 16 | (prediction & 65535);
 }
 
 // Smoothed trend: applies the gradient at half strength instead of full extrapolation.
 // prediction = avg(origin, origin + (px - pxFar))
-// spread = abs(px - pxFar): same signal as Trend.
+// spread = rabs(px - pxFar): same signal as Trend.
 // Use in smoother regions where a full trend extrapolation would overshoot,
 // or when the gradient is expected to taper rather than continue linearly.
 ALWAYS_INLINE void Image24BitModel::MakePredictionSmooth(int i, int px, int pxFar, int origin) {
-  uint32_t absdiff = abs(px - pxFar);
+  uint32_t absdiff = rabs(px, pxFar);
   int prediction = avg(origin, origin + px - pxFar);
+  predictions[i] = absdiff << 16 | (prediction & 65535);
+}
+
+ALWAYS_INLINE void Image24BitModel::MakePredictionAvg(int i, int px1, int px2) {
+  uint32_t absdiff = rabs(px1, px2);
+  int prediction = avg(px1, px2);
   predictions[i] = absdiff << 16 | (prediction & 65535);
 }
 
@@ -117,11 +153,24 @@ void Image24BitModel::update() {
   INJECT_SHARED_bpos
   INJECT_SHARED_c1
 
-  if (color != 4) // no need to accumulate loss from the padding zone
-    loss += shared->State.loss; // += 0..255
+  if (color < 4) // no need to accumulate loss from the padding zone
+    loss += shared->State.loss; // += 0..1023
 
   // for every byte
   if (bpos == 0) {
+
+    INJECT_SHARED_pos
+    if (pos - lastPos != 1) {
+      init();
+    }
+    else {
+      x++;
+      if (x >= w) {
+        x = 0;
+        line++;
+      }
+    }
+    lastPos = pos;
 
     INJECT_SHARED_buf
     if (x == 0) {
@@ -136,14 +185,10 @@ void Image24BitModel::update() {
       color = 4; // flag for padding zone
     }
 
-    if (color != 4) { // we are in the pixel area
+    if (color < 4) { // we are in the pixel area
 
-      assert((loss >> 3) <= 255);
-      lossBuf.add(static_cast<uint8_t>(loss >> 3));  // 0..31
+      lossBuf.add(static_cast<uint8_t>(min(loss >> 2, 255)));  // 0..255
       loss = 0;
-
-      column[0] = x / columns[0];
-      column[1] = x / columns[1];
 
       WWWWWW = Px(6, 0, 0); //buf(6*stride)
       WWWWW = Px(5, 0, 0); //buf(5*stride)
@@ -242,7 +287,42 @@ void Image24BitModel::update() {
       uint8_t NNNNWWWW = Px(4, 4, 0); //buf(4*stride + 4*w)
       uint8_t NNNNEEEE = Px(-4, 4, 0); //buf(-4*stride + 4*w)
       uint8_t NEEEEEE = Px(-6, 1, 0); //buf(-6*stride + 1*w)
-      uint8_t NNNNWWW = Px(4, 3, 0); //buf(4*stride + 3*w)
+      uint8_t NNNWWWW = Px(4, 3, 0); //buf(4*stride + 3*w)
+      uint8_t NNNEEEE = Px(-4, 3, 0); //buf(-4*stride + 3*w)
+
+      // mixer context: edge detection
+
+      // Vertical ↓ (0)
+      int r_N_vert = rabs(N, (NN * 2 - NNN));
+      int r_W_vert = rabs(W, (NW * 2 - NNW));
+      int r_NE_vert = rabs(NE, (NNE * 2 - NNNE));
+      int score_vert = (2 * r_N_vert + r_W_vert + r_NE_vert) / 4;
+
+      // Horizontal → (1)
+      int r_W_horiz = rabs(W, (WW * 2 - WWW));
+      int r_N_horiz = rabs(N, (NW * 2 - NWW));
+      int score_horiz = (2 * r_W_horiz + r_N_horiz) / 3;
+
+      // Diagonal ↘ (2)
+      int r_NW_diag1 = rabs(NW, (NNWW * 2 - NNNWWW));
+      int r_N_diag1 = rabs(N, (NNW * 2 - NNNWW));
+      int r_W_diag1 = rabs(W, (NWW * 2 - NNWWW));
+      int score_diag1 = (2 * r_NW_diag1 + r_N_diag1 + r_W_diag1) / 4;
+
+      // Diagonal ↙ (3)
+      int r_NE_diag2 = rabs(NE, (NNEE * 2 - NNNEEE));
+      int r_N_diag2 = rabs(N, (NNE * 2 - NNNEE));
+      int r_NEE_diag2 = rabs(NEE, (NNEEE * 2 - NNNEEEE));
+      int score_diag2 = (2 * r_NE_diag2 + r_N_diag2 + r_NEE_diag2) / 4;
+
+      ctx_best_direction = 0; // 0..3
+
+      int ctx_best_score = score_vert;
+      if (score_horiz < ctx_best_score) { ctx_best_score = score_horiz; ctx_best_direction = 1; }
+      if (score_diag1 < ctx_best_score) { ctx_best_score = score_diag1; ctx_best_direction = 2; }
+      if (score_diag2 < ctx_best_score) { ctx_best_score = score_diag2; ctx_best_direction = 3; }
+
+      ctx_best_residual = DiffQt(0, ctx_best_score); // 0..7
 
       //what was the total cost at the neighboring pixes of this same channel
       lossQ = //0 x 6 .. 255 x 6 = 0 .. 1530
@@ -255,21 +335,33 @@ void Image24BitModel::update() {
 
       // let's trim the higher part (640-1530) - it is almost always completely empty OR such high values indicate that we are off frame
       // cap at 639 = 16*40 - 1, so lossQ4 = lossQ/40 fits in [0..15]
-      lossQ = min(lossQ, 639); 
+      lossQ = min(lossQ, 639);
       shared->State.Image.lossQ = lossQ; //0..639
 
-      // Written in reverse order (nDM-1 down to 0) so that GetPredErr()'s
-      // read formula  predErr(offset * nDM + ctxIndex + 1)  resolves correctly:
+      // Written in reverse order (nDM+nOLS-1 down to 0) so that GetPredErr()'s
+      // read formula  predErr((offset-1) * (nDM+nOLS) + ctxIndex + 1)  resolves correctly:
       // after writing nDM values, predictor ctxIndex sits at ring offset -(ctxIndex+1).
-      for (int i = nDM - 1; i >= 0; i--) {
+
+
+      uint32_t lowestErr = 255;
+      uint8_t bestPredictorIndex = 0;
+      static_assert(nDM + nOLS <= 255); // the index need to fit to a byte
+      for (int i = nDM + nOLS - 1; i >= 0; i--) {
         short prediction = predictions[i] & 65535;
         uint8_t err;
         if (prediction == INT16_MAX) // currently never happens, todo
           err = 255;
         else
-          err = abs(int8_t((c1 - prediction) & 255));
+          err = rabs(c1, prediction); // 0..128
         predErrBuf.add(err); //0..63 or 255
+
+        uint32_t linearError = abs(c1 - prediction);
+        if (linearError < lowestErr) {
+          lowestErr = linearError;
+          bestPredictorIndex = i;
+        }
       }
+      bestPredictorIndexes.add(bestPredictorIndex);
 
       // these contexts are best for photographic images
 
@@ -277,10 +369,8 @@ void Image24BitModel::update() {
 
       //for tuning:
       //int z = 0;
-      //int toadd = shared->tuning_param - 1 + z;
-      //if (toskip != z) MakePredictionC(contextIdx++, p1); z++;
-      //if (toadd == z) MakePredictionC(contextIdx++, p1); z++;
-
+      //int toskip = shared->tuning_param + z;
+      //z++; if (toskip != z) MakePredictionC(contextIdx++, p1);
 
       // note about p1 and p2:
       // their semantics change depending on 'color':
@@ -290,18 +380,28 @@ void Image24BitModel::update() {
       //  color = 2 (B) -> p1 =  current pixel's G, p2 =  current pixel's R <- this is the intention
 
       // p1-based predictors
-      
+
       MakePredictionC(contextIdx++, p1); // very strong
+
       MakePredictionTrend(contextIdx++, p1, Np1, N); // strong
       MakePredictionSmooth(contextIdx++, p1, Np1, N); // strong
+      MakePrediction(contextIdx++, p1, Np1, N);
+
       MakePredictionTrend(contextIdx++, p1, Wp1, W);
       MakePredictionSmooth(contextIdx++, p1, Wp1, W);
+      MakePrediction(contextIdx++, p1, Wp1, W);
+
       MakePredictionTrend(contextIdx++, p1, NEp1, NE); // very strong
+      MakePrediction(contextIdx++, p1, NEp1, NE);
       MakePredictionTrend(contextIdx++, p1, NNp1, NN); // very strong
+      MakePrediction(contextIdx++, p1, NNp1, NN);
 
       MakePredictionTrend(contextIdx++, p1, NWp1, NW);
       MakePredictionSmooth(contextIdx++, p1, NWp1, NW);
+      MakePrediction(contextIdx++, p1, NWp1, NW);
+
       MakePredictionTrend(contextIdx++, p1, WWp1, WW);
+      MakePrediction(contextIdx++, p1, WWp1, WW);
 //    MakePredictionSmooth(contextIdx++, p1, WWp1, WW); // weak
 
       MakePredictionSmooth(contextIdx++, p1, NNEEp1, NE);
@@ -330,10 +430,13 @@ void Image24BitModel::update() {
       // p2-based predictors
 
       MakePredictionC(contextIdx++, p2); // very strong
+
       MakePredictionTrend(contextIdx++, p2, Np2, N);
       MakePredictionSmooth(contextIdx++, p2, Np2, N);
+
       MakePredictionTrend(contextIdx++, p2, Wp2, W);
       MakePredictionSmooth(contextIdx++, p2, Wp2, W);
+
       MakePredictionTrend(contextIdx++, p2, NEp2, NE);
       MakePredictionTrend(contextIdx++, p2, NNp2, NN);
       MakePredictionSmooth(contextIdx++, p2, NWp2, NW); 
@@ -363,13 +466,10 @@ void Image24BitModel::update() {
       
       // predictors using only the current color plane
       
-      MakePredictionC(contextIdx++,(N * 3 + W * 3 - NN - WW + 2) >> 2);
-      MakePrediction(contextIdx++, W, NEE, avg(W, NEE));
-      MakePredictionC(contextIdx++, ((WWW - 4 * WW + 6 * W + (NE * 4 - NNE * 6 + NNNE * 4 - NNNNE)) / 4));
-      MakePredictionC(contextIdx++, ((-WWWW + 5 * WWW - 10 * WW + 10 * W + (NE * 4 - NNE * 6 + NNNE * 4 - NNNNE)) / 5));
-      MakePredictionC(contextIdx++, ((-4 * WW + 15 * W + 10 * (NE * 3 - NNE * 3 + NNNE) - (NEEE * 3 - NNEEE * 3 + NNNEEE)) / 20));
-      MakePredictionC(contextIdx++, ((-3 * WW + 8 * W + (NEE * 3 - NNEE * 3 + NNNEE)) / 6));
-      
+      MakePredictionC(contextIdx++, (N * 3 + W * 3 - NN - WW + 2) >> 2);
+      MakePredictionAvg(contextIdx++, W, NEE);
+
+
       MakePredictionTrend(contextIdx++, W, NW, N); // very strong
       MakePredictionTrend(contextIdx++, WW, NNWW, NN); //strong?
       MakePredictionTrend(contextIdx++, WWW, NNNWWW, NNN); //strong?
@@ -404,23 +504,23 @@ void Image24BitModel::update() {
       MakePredictionC(contextIdx++, clamp4(N * 3 - NN * 3 + NNN, N, W, NE, NW)); // very strong
       MakePredictionC(contextIdx++, clamp4(W * 3 - WW * 3 + WWW, N, W, NE, NW)); // strong
       
-      MakePredictionC(contextIdx++, ((NNNNN - 6 * NNNN + 15 * NNN - 20 * NN + 15 * N + clamp4(W * 4 - NWW * 6 + NNWWW * 4 - NNNNWWW, W, NW, N, NN)) / 6)); // very strong
-      MakePredictionC(contextIdx++, ((NNNEEE - 4 * NNEE + 6 * NE + (W * 4 - NW * 6 + NNW * 4 - NNNW)) / 4));
+      MakePredictionC(contextIdx++, ((15 * N - 20 * NN + 15 * NNN - 6 * NNNN + NNNNN + clamp4(4 * W - 6 * NWW + 4 * NNWWW - NNNWWWW, W, NW, N, NN)) / 6)); // very strong
+      MakePredictionC(contextIdx++, ((6 * NE - 4 * NNEE + NNNEEE + (4 * W - 6 * NW + 4 * NNW - NNNW)) / 4));
       MakePredictionC(contextIdx++, (((N + 3 * NW) / 4) * 3 - avg(NNW, NNWW) * 3 + (NNNWW * 3 + NNNWWW) / 4));
       MakePredictionC(contextIdx++, ((W * 2 + NW) - (WW + 2 * NWW) + NWWW)); // strong
 //    MakePredictionC(contextIdx++, ((W * 2 - NW) + (W * 2 - NWW) + N + NE) / 4);  // weak
 //    MakePredictionSmooth(contextIdx++, avg(N, W), N, W);  // weak
-      MakePredictionC(contextIdx++, avg(NEEEE, NEEEEEE)); // strong
-      MakePredictionC(contextIdx++, avg(WWWWWW, WWWW));
-      MakePredictionC(contextIdx++, avg(NNNN, NNNNNN));// strong
+      MakePredictionAvg(contextIdx++, NEEEE, NEEEEEE); // strong
+      MakePredictionAvg(contextIdx++, WWWW, WWWWWW);
+      MakePredictionAvg(contextIdx++, NNNN, NNNNNN);// strong
 //    MakePredictionTrend(contextIdx++, NNNN, NNNNNN, NN); // weak
 //    MakePredictionC(contextIdx++, avg(NNNNWWWW, NNWW)); // weak
 //    MakePredictionC(contextIdx++, avg(NNNNEEEE, NNEE)); // weak
-      MakePredictionC(contextIdx++, avg(NNNNWW, NNWW));
-      MakePredictionC(contextIdx++, avg(NNNNEE, NNEE));
+      MakePredictionAvg(contextIdx++, NNNNWW, NNWW);
+      MakePredictionAvg(contextIdx++, NNNNEE, NNEE);
 //    MakePredictionTrend(contextIdx++, NNEE, NNNNEEEE, NNEE); // weak
 //    MakePredictionTrend(contextIdx++, NNEE, NNNNEE, NE); // weak
-      MakePredictionC(contextIdx++, avg(WWWWWW, WWW));
+      MakePredictionAvg(contextIdx++, WWW, WWWWWW);
 //    MakePredictionTrend(contextIdx++, WWW, WWWWWW, W);
 //    MakePredictionTrend(contextIdx++, WWWW, WWWWWW, WW); // weak
       MakePredictionC(contextIdx++, W);
@@ -431,22 +531,91 @@ void Image24BitModel::update() {
       MakePredictionTrend(contextIdx++, WW, WWWW, WW); // strong?
       MakePredictionTrend(contextIdx++, N, NN, N); // strong
       MakePredictionTrend(contextIdx++, NN, NNNN, NN);
-      MakePredictionTrend(contextIdx++, NW, NNWW, NW); 
+      MakePredictionTrend(contextIdx++, NW, NNWW, NW);
       MakePredictionTrend(contextIdx++, NNWW, NNNNWWWW, NNWW);
       MakePredictionTrend(contextIdx++, NE, NNEE, NE);
       MakePredictionTrend(contextIdx++, NNEEE, NNNNEEEE, NNEEE);
 
-      MakePredictionC(contextIdx++, avg(2 * N - NN, 2 * W - WW));
-      MakePredictionC(contextIdx++, avg(2 * W - WW, 2 * NW - NNWW));
+      MakePredictionAvg(contextIdx++, 2 * N - NN, 2 * W - WW);
+      MakePredictionAvg(contextIdx++, 2 * W - WW, 2 * NW - NNWW);
 
       MakePredictionC(contextIdx++, paeth(W, N, NW));
       MakePredictionC(contextIdx++, gap(W, N, NW, NE, WW, NNE, NN));
+
+      // 3rd-order horizontal + 4th-order NE diagonal
+      MakePredictionC(contextIdx++, (6 * W - 4 * WW + WWW + 4 * NE - 6 * NNE + 4 * NNNE - NNNNE) / 4);
+      // average of 1st- through 4th-order horizontal + 4th-order NE diagonal
+      MakePredictionC(contextIdx++, (10 * W - 10 * WW + 5 * WWW - WWWW + 4 * NE - 6 * NNE + 4 * NNNE - NNNNE) / 5);
+      // 2nd-order H + weighted blend of 3rd-order NE and 3rd-order NEEE diagonals
+      MakePredictionC(contextIdx++, (15 * W - 4 * WW + 10 * (3 * NE - 3 * NNE + NNNE) - (3 * NEEE - 3 * NNEEE + NNNEEE)) / 20); //strong
+      // 2× 1st-order + 3× 2nd-order horizontal + 3rd-order NEE diagonal
+      MakePredictionC(contextIdx++, (8 * W - 3 * WW + (3 * NEE - 3 * NNEE + NNNEE)) / 6); // very strong
+
+      // 2nd-order H + 2nd-order V, interaction-corrected
+      MakePredictionC(contextIdx++, (2 * W - WW) + (2 * N - NN) - (2 * NW - NNWW));
+
+      // 3rd-order horizontal + 4th-order NW diagonal
+//    MakePredictionC(contextIdx++, (6 * W - 4 * WW + WWW + 4 * NW - 6 * NNW + 4 * NNNW - NNNNW) / 4); // weak
+      // 4th-order horizontal + 4th-order NW diagonal
+//    MakePredictionC(contextIdx++, (10 * W - 10 * WW + 5 * WWW - WWWW + 4 * NW - 6 * NNW + 4 * NNNW - NNNNW) / 5); // weak
+
+      // 3rd-order vertical + 4th-order NE diagonal
+      MakePredictionC(contextIdx++, (6 * N - 4 * NN + NNN + 4 * NE - 6 * NNE + 4 * NNNE - NNNNE) / 4);
+      // 4th-order vertical + 4th-order NE diagonal
+      MakePredictionC(contextIdx++, ((10 * N - 10 * NN + 5 * NNN - NNNN) + (4 * NE - 6 * NNE + 4 * NNNE - NNNNE)) / 5);
+
+      // 3rd-order vertical + 4th-order NW diagonal
+      MakePredictionC(contextIdx++, (6 * N - 4 * NN + NNN + 4 * NW - 6 * NNW + 4 * NNNW - NNNNW) / 4);
+      // 4th-order vertical + 4th-order NW diagonal
+      MakePredictionC(contextIdx++, ((10 * N - 10 * NN + 5 * NNN - NNNN) + (4 * NW - 6 * NNW + 4 * NNNW - NNNNW)) / 5);
+
+      // 3rd-order NE diagonal alone
+      MakePredictionC(contextIdx++, (6 * NE - 4 * NNEE + NNNEEE) / 3);
+      // 3rd-order NW diagonal alone
+//    MakePredictionC(contextIdx++, (6 * NW - 4 * NNWW + NNNWWW) / 3); // weak
+
+      // 3rd-order H + 3rd-order V, interaction-corrected
+      MakePredictionC(contextIdx++, ((6 * W - 4 * WW + WWW) + (6 * N - 4 * NN + NNN) - (6 * NW - 4 * NNWW + NNNWWW)) / 3);
+
+      // 5th-order horizontal
+      MakePredictionC(contextIdx++, (15 * W - 20 * WW + 15 * WWW - 6 * WWWW + WWWWW) / 5); // strong
+
+      // symmetric NE+NW blend, N-corrected
+      MakePredictionC(contextIdx++, (2 * NE - NNEE) + (2 * NW - NNWW) - (2 * N - NN));
+
+      // 2nd-order H + 2nd-order V + 2nd-order NE + 2nd-order NW, fully interaction-corrected
+//    MakePredictionC(contextIdx++, (2 * W - WW) + (2 * N - NN) - (2 * NE - NNEE));
+
+      // 4th-order horizontal
+//    MakePredictionC(contextIdx++, (10 * W - 10 * WW + 5 * WWW - WWWW) / 4);
+
+      // 3rd-order vertical
+//    MakePredictionC(contextIdx++, (6 * N - 4 * NN + NNN) / 3);
+
+      // 4th-order vertical
+//    MakePredictionC(contextIdx++, (10 * N - 10 * NN + 5 * NNN - NNNN) / 4);
+      // 5th-order vertical
+//    MakePredictionC(contextIdx++, (15 * N - 20 * NN + 15 * NNN - 6 * NNNN + NNNNN) / 5);
+
+      // 2nd-order NE diagonal
+//    MakePredictionC(contextIdx++, (2 * NE - NNEE));
+
+      // 2nd-order NW diagonal
+//    MakePredictionC(contextIdx++, (2 * NW - NNWW));
+
 
       MakePredictionC(contextIdx++, 0);
 
       assert(contextIdx == nDM);
 
-      uint32_t lossQ4 = (lossQ / 40u);  //0..15 (4 bits)
+      //quality metric: quantized past loss in the pixel neighborhood 
+      lossQ4 =
+        color == 2 ? (lossQ < 1 ? lossQ : min(1 + ((lossQ - 1) / 40u), 7)) :
+        color == 1 ? (lossQ < 8 ? (lossQ >> 2) : min(2 + ((lossQ - 8) / 40u), 7)) :
+        min(lossQ / 40u, 7); //0..7 (3 bits)
+
+      // map the predictions to histograms
+
       for (int i = 0; i < nDM; i++) {
         uint32_t spread = predictions[i] >> 16;
         short prediction = predictions[i] & 65535;
@@ -456,37 +625,34 @@ void Image24BitModel::update() {
           mapR3.skip();
         }
         else {
-          // Curent pixel's prediction confidence is based on the already known error at neighboring pixel predictions
-          uint8_t predErrW = GetPredErr(i, 1, 0); //W
-          uint8_t predErrN = GetPredErr(i, 0, 1); //N
-          uint8_t predErrNW = GetPredErr(i, 1, 1); //NW
-          uint8_t predErrNE = GetPredErr(i, -1, 1); //NE
-          uint32_t predErrAvg = (predErrW + predErrN + predErrNE + predErrNW + 2) >> 2; //0..255
-          mapR1.set(prediction, min(predErrAvg, 31) << 2 | color); //5+2 bits
-          mapR2.set(prediction, lossQ4 << 2 | color); //0..31, 0..3 (5+2 bits)
-          mapR3.set(prediction, min(spread, 31) << 2 | color); //5+2 bits
+          uint32_t predErrAvg = GetPredErrAvg(i);
+          mapR1.set(prediction, min(predErrAvg, 31) << 2 | color); // 0..31, 0..3 (5+2 bits)
+          mapR2.set(prediction, lossQ4 << 2 | color); // 0..7, 0..3 (3+2 bits)
+          mapR3.set(prediction, min(spread, 31) << 2 | color); // 5+2 bits
         }
       }
 
-      int k = (color > 0) ? color - 1 : stride - 1; //previous color index
+      // OLS predictors
+
+      int k = (color > 0) ? color - 1 : stride - 1; // previous color index
       for (int j = 0; j < nOLS; j++) {
+        ols[j][k]->update(p1);
         auto ols_j_color = ols[j][color].get();
         auto ols_ctx_j = olsCtxs[j];
         for (int ctx_idx = 0; ctx_idx < num[j]; ctx_idx++) {
           float val = *ols_ctx_j[ctx_idx];
           ols_j_color->add(val);
         }
-        float prediction = ols_j_color->predict();
-        pOLS[j] = clip(int(roundf(prediction)));
-        ols[j][k]->update(p1);
+        float pred = ols_j_color->predict();
+        short prediction = short(roundf(pred));
+        MakePredictionC(contextIdx++, prediction);
+
+        uint32_t predErrAvg = GetPredErrAvg(j + nDM);
+        mapOLS1.set(prediction, min(predErrAvg, 31) << 2 | color); // 0..31, 0..3 (5+2 bits)
+        mapOLS2.set(prediction, lossQ4 << 2 | color); // 0..7, 0..3 (3+2 bits)
       }
 
-      int mean = (W + NW + N + NE + 2) >> 2;
-      int diff4 =
-        DiffQt(W, N, 4) << 12 |
-        DiffQt(NW, NE, 4) << 8 |
-        DiffQt(NW, N, 4) << 4 |
-        DiffQt(W, NE, 4);
+      assert(contextIdx == nDM + nOLS);
 
       // these contexts are best for non-photographic images (logos, icons, screenshots, infographics)
       // todo: review and optimize these contexts
@@ -502,14 +668,17 @@ void Image24BitModel::update() {
       cm.set(R_, hash(++i, W, p2));
       cm.set(R_, hash(++i, N, p1));
       cm.set(R_, hash(++i, N, p2));
+      cm.set(R_, hash(++i, p1, p2));
       cm.set(R_, hash(++i, N, NN, p1));
       cm.set(R_, hash(++i, N, NN, p2));
       cm.set(R_, hash(++i, W, WW, p1));
       cm.set(R_, hash(++i, W, WW, p2));
       cm.set(R_, hash(++i, N, W, p1, p2));
+
+      cm.set(R_, hash(++i, W, WW, N, NN));
+      cm.set(R_, hash(++i, W, N, NE, NW));
       
       cm.set(R_, hash(++i, (NNN + N + 4) >> 3, (N * 3 - NN * 3 + NNN) >> 1));
-      cm.set(R_, hash(++i, ((-WWWW + 5 * WWW - 10 * WW + 10 * W + clamp4(NE * 4 - NNE * 6 + NNNE * 4 - NNNNE, N, NE, NEE, NEEE)) / 5) / 4));
       cm.set(R_, hash(++i, (W + N - NW) >>1, (W + p1 - Wp1) >>1));
       cm.set(R_, hash(++i, W >> 2, DiffQt(W, p1), DiffQt(W, p2)));
       cm.set(R_, hash(++i, N >> 2, DiffQt(N, p1), DiffQt(N, p2)));
@@ -523,38 +692,41 @@ void Image24BitModel::update() {
       cm.set(R_, hash(++i, (W * 2 - WW), DiffQt(N, (NW * 2 - NWW))));
       cm.set(R_, hash(++i, (W + NEE + 1) >> 1, DiffQt(W, (WW + NE + 1) >> 1)));
       cm.set(R_, hash(++i, (W + NEE - NE), DiffQt(W, (WW + NE - N))));
-      cm.set(R_, hash(++i, (clamp4((W * 2 - WW) + (N * 2 - NN) - (NW * 2 - NNWW), W, NW, N, NE))));
-      cm.set(R_, hash(++i, (W + N - NW), column[0]));
       cm.set(R_, hash(++i, N, NN, NNN));
       cm.set(R_, hash(++i, W, WW, WWW));
-      cm.set(R_, hash(++i, N, column[0]));
-      cm.set(R_, hash(++i, column[1]));
-      cm.set(R_, hash(++i, mean, diff4));
+
+      int div7 = max((x / stride) >> 10, 7);
+      int div17 = max((x / stride) >> 9, 17);
+      int div29 = max((x / stride) >> 8, 29);
+
+      cm.set(R_, hash(++i, w, x / stride / div7));
+      cm.set(R_, hash(++i, w, x / stride / div17, line / 17));
+      cm.set(R_, hash(++i, w, x / stride / div29, uint8_t(W + N - NW) >> 1));
 
       assert(i - color * 1024 == nCM);
 
-      // todo: review and optimize these contexts
+      ctx[0] =  // 9 bits
+        (static_cast<int>(rabs(W, NW) > 3) << 8) |
+        (static_cast<int>(rabs(NW, N) > 3) << 7) |
+        (static_cast<int>(rabs(N, NE) > 3) << 6) |
+        (static_cast<int>(N > NW) << 5) |
+        (static_cast<int>(N > NE) << 4) |
+        (static_cast<int>(N > NN) >> 3) |
+        (static_cast<int>(W > N) << 2) |
+        (static_cast<int>(W > NW) << 1) |
+        (static_cast<int>(W > WW) << 0);
 
-      ctx[0] = (min(color,stride - 1) << 9) |
-        (static_cast<int>(abs(W - N) > 3) << 8) |
-        (static_cast<int>(W > N) << 7) |
-        (static_cast<int>(W > NW) << 6) |
-        (static_cast<int>(abs(N - NW) > 3) << 5) |
-        (static_cast<int>(N > NW) << 4) |
-        (static_cast<int>(abs(N - NE) > 3) << 3) |
-        (static_cast<int>(N > NE) << 2) |
-        (static_cast<int>(W > WW) << 1) |
-        static_cast<int>(N > NN);
-      ctx[1] = ((DiffQt(p1, (Np1 + NEp1 - buf(w * 2 - stride + 1))) >> 1) << 5) |
-        ((DiffQt((N + NE - NNE), (N + NW - NNW)) >> 1) << 2) |
-        min(color, stride - 1);
 
-      shared->State.Image.plane = min(color, stride - 1);
+      ctx[1] =  // 8 bits
+        (DiffQt(p1, (Np1 + NEp1 - NNEp1))) << 4 |
+        (DiffQt((N + NE - NNE), (N + NW - NNW)));
+
+      shared->State.Image.plane = color;
       shared->State.Image.pixels.W = W;
       shared->State.Image.pixels.N = N;
       shared->State.Image.pixels.NN = NN;
       shared->State.Image.pixels.WW = WW;
-      shared->State.Image.ctx = ctx[0] >> 3;
+      shared->State.Image.ctx = ((color << 9) | ctx[0]) >> 3; // 8 bits
     }
   }
 
@@ -563,26 +735,30 @@ void Image24BitModel::update() {
   if (color != 4) {
     INJECT_SHARED_c0
 
-    //these contexts are best for non-photographic images (logos, icons, screenshots, infographics)
-    //but they also work well for modelling with the direct pixel neigborhood in not-too-noisy photographic images
+      //these contexts are best for non-photographic images (logos, icons, screenshots, infographics)
+      //but they also work well for modelling with the direct pixel neigborhood in not-too-noisy photographic images
 
-    int i = (c0 << 2 | color) * 256;
+      int i = (c0 << 2 | color) * 256;
 
-    mapL.set(hash(++i, p2)); // strong
+    //for tuning:
+    //int toskip = shared->tuning_param - 1 + i;
+    //if (toskip == i) mapL.skip(), i++; else 
+
+    mapL.set(hash(++i, p2)); // very strong
     mapL.set(hash(++i, p1, p2)); // strong
 
     // W
-    mapL.set(hash(++i, W, p1));
+//  mapL.set(hash(++i, W, p1)); // weak
     mapL.set(hash(++i, W, p2)); // strong
     mapL.set(hash(++i, W, p1, p2));
 
     // N
-    mapL.set(hash(++i, N, p1)); // strong
-    mapL.set(hash(++i, N, p2));
+//  mapL.set(hash(++i, N, p1)); // weak
+//  mapL.set(hash(++i, N, p2)); // weak
     mapL.set(hash(++i, N, Np1, Np2));
 
     // W + N
-    mapL.set(hash(++i, W, N, p1, p2));
+//  mapL.set(hash(++i, W, N, p1, p2));  // weak
     mapL.set(hash(++i, W, p1, p2, N, Np1));
     mapL.set(hash(++i, W, p1, p2, N, Np1, Np2));
 
@@ -593,18 +769,19 @@ void Image24BitModel::update() {
 
 
     // N + NW
-    mapL.set(hash(++i, N, NW, p2));
+//  mapL.set(hash(++i, N, NW, p2)); // weak
 
     // N + NE
     mapL.set(hash(++i, N, NE, p1));
-    mapL.set(hash(++i, N, NE, p2));
+//  mapL.set(hash(++i, N, NE, p2)); // weak
 
     //N + NN
-    mapL.set(hash(++i, N, NN, p1));
+//  mapL.set(hash(++i, N, NN, p1));  // weak
+//  mapL.set(hash(++i, N, NN, p2)); // weak
 
     // W + WW
-    mapL.set(hash(++i, W, WW, p1));
-    mapL.set(hash(++i, W, WW, p2));
+//  mapL.set(hash(++i, W, WW, p1)); // weak
+//  mapL.set(hash(++i, W, WW, p2)); // weak
 
     // NW + NE (cross-diagonal)
     mapL.set(hash(++i, NW, NE, p1));
@@ -618,40 +795,63 @@ void Image24BitModel::update() {
 
     // W + N + NW
     mapL.set(hash(++i, W, N, NW, p1));
-    mapL.set(hash(++i, W, p1, p2, N, NW, NWp1));
+//  mapL.set(hash(++i, W, p1, p2, N, NW, NWp1)); //weak
 
     // N + NE + NW
     mapL.set(hash(++i, N, Np1, NE, NW, p1));
 
-    mapL.set(hash(++i, NE, NEE, p1));
+    mapL.set(hash(++i, NE, NEE, p1)); // strong
     mapL.set(hash(++i, NE, NEE, p2));
-    mapL.set(hash(++i, NE, NEp1, NEp2, NEE));
+    mapL.set(hash(++i, NE, NEp1, NEp2, NEE)); // strong
 
     mapL.set(hash(++i, NN, NNN, p1));
     mapL.set(hash(++i, NN, NNN, p2));
     mapL.set(hash(++i, NN, NNp1, NNp2, NNN));
 
-    mapL.set(hash(++i, WW, WWW, p1));
-    mapL.set(hash(++i, WW, WWW, p2));
+//  mapL.set(hash(++i, WW, WWW, p1)); // weak
+//  mapL.set(hash(++i, WW, WWW, p2)); // weak
     mapL.set(hash(++i, WW, WWp1, WWp2, WWW));
 
-    mapL.set(hash(++i, Np1, Np2, Wp1, Wp2));  // neighbor cross-plane
+    mapL.set(hash(++i, Np1, Np2, Wp1, Wp2));
     mapL.set(hash(++i, NWp1, NWp2, NEp1, NEp2));
 
-    mapL.set(hash(++i, (W + N - NW) >> 1, p1));  // strong         // gradient corrector
-    mapL.set(hash(++i, (W + N - NW) >> 1, p1, p2)); // strong
-    mapL.set(hash(++i, (N + NE - NNE) >> 1, p1)); // very strong    horizontal extrapolation error 
-    mapL.set(hash(++i, (W * 2 - WW) >> 1, p1)); // W trend
-    mapL.set(hash(++i, (N * 2 - NN) >> 1, p1)); // N trend
+    mapL.set(hash(++i, (W + N - NW) >> 1, p1));  // very strong
+    mapL.set(hash(++i, (W + N - NW) >> 1, p1, p2)); // very strong
+    mapL.set(hash(++i, (N + NE - NNE) >> 1, p1)); // strong
+    mapL.set(hash(++i, (N + NE - NNE) >> 1, p1, p2));
+    mapL.set(hash(++i, (W * 2 - WW) >> 1, p1));
+    mapL.set(hash(++i, (N * 2 - NN) >> 1, p1));
+    mapL.set(hash(++i, (W * 2 - WW) >> 1, p1, p2));
+    mapL.set(hash(++i, (N * 2 - NN) >> 1, p1, p2));
 
+    mapL.set(hash(++i, (NW + W - NWW) >> 1, p1));
+    mapL.set(hash(++i, (NW + W - NWW) >> 1, p1, p2));
+    mapL.set(hash(++i, (NW + N - NNW) >> 1, p1));
+    mapL.set(hash(++i, (NW + N - NNW) >> 1, p1, p2));
+
+//  mapL.set(hash(++i, (NE * 2 - NNEE) >> 1, p1)); 
+//  mapL.set(hash(++i, (NE * 2 - NNEE) >> 1, p1, p2));
+//  mapL.set(hash(++i, (NW * 2 - NNWW) >> 1, p1));
+//  mapL.set(hash(++i, (NW * 2 - NNWW) >> 1, p1, p2)); // weak
+
+//  mapL.set(hash(++i, ((W * 2 - WW) + (N * 2 - NN) - (NW * 2 - NNWW)) >> 1, p1)); // weak
+//  mapL.set(hash(++i, ((W * 2 - WW) + (N * 2 - NN) - (NW * 2 - NNWW)) >> 1, p1, p2)); // weak
+
+//  mapL.set(hash(++i, (N * 3 - NN * 3 + NNN) >> 1, p1));
+//  mapL.set(hash(++i, (W * 3 - WW * 3 + WWW) >> 1, p1));
+//  mapL.set(hash(++i, (N * 3 - NN * 3 + NNN) >> 1, p1, p2)); // weak
+//  mapL.set(hash(++i, (W * 3 - WW * 3 + WWW) >> 1, p1, p2)); // weak
+
+//  mapL.set(hash(++i, ((NE * 2 - NNEE) + (NW * 2 - NNWW) - (N * 2 - NN)) >> 1, p1)); // weak
+//  mapL.set(hash(++i, ((NE * 2 - NNEE) + (NW * 2 - NNWW) - (N * 2 - NN)) >> 1, p1, p2));
+
+    mapL.set(hash(++i, paeth(W, N, NW) >> 1, p1));
+    mapL.set(hash(++i, paeth(W, N, NW) >> 1, p1, p2)); // strong
+//  mapL.set(hash(++i, gap(W, N, NW, NE, WW, NNE, NN) >> 1, p1)); // weak
 
     assert(i - ((c0 << 2 | color) * 256) == nLSM);
 
 
-    uint8_t b = (c0 << (8 - bpos));
-    for (int i = 0; i < nSM; i++) {
-      map[i].set(static_cast<uint8_t>(pOLS[i] - b) << 3 | bpos);
-    }
   }
 }
 
@@ -659,21 +859,18 @@ void Image24BitModel::init() {
   stride = 3 + alpha;
   padding = w % stride;
   x = color = line = 0;
-  columns[0] = max(1, w / max(1, ilog2(w) * 3));
-  columns[1] = max(1, columns[0] / max(1, ilog2(columns[0])));
   if( lastPos > 0 && false ) { // todo: when shall we reset?
     for (int i = 0; i < nLSM; i++) {
       mapL.reset();
-    }
-    for( int i = 0; i < nSM; i++ ) {
-      map[i].reset();
     }
   }
   lossBuf.setSize(nextPowerOf2(LOSS_BUF_ROWS * w));
   lossBuf.fill(255);
 
-  predErrBuf.setSize(nextPowerOf2(PRED_ERR_BUF_ROWS * w * nDM));
+  predErrBuf.setSize(nextPowerOf2(PRED_ERR_BUF_ROWS * w * (nDM + nOLS)));
   predErrBuf.fill(255);
+
+  bestPredictorIndexes.setSize(nextPowerOf2(BEST_PRED_ROWS * w));
 }
 
 void Image24BitModel::setParam(int width, uint32_t alpha0) {
@@ -682,66 +879,90 @@ void Image24BitModel::setParam(int width, uint32_t alpha0) {
 }
 
 void Image24BitModel::mix(Mixer &m) {
-  INJECT_SHARED_bpos
-  if( bpos == 0 ) {
-    INJECT_SHARED_pos
-    if(pos - lastPos != 1) {
-      init();
-    } else {
-      x++;
-      if( x >= w ) {
-        x = 0;
-        line++;
-      }
-    }
-    lastPos = pos;
-  }
-
-  update();
 
   // predict next bit
-  if (color != 4) {
+  if (color < 4) { // pixel area
     cm.mix(m);
 
     mapR1.mix(m);
     mapR2.mix(m);
     mapR3.mix(m);
-
+    mapOLS1.mix(m);
+    mapOLS2.mix(m);
     mapL.mix(m);
-
-    for( int i = 0; i < nSM; i++ ) {
-      map[i].mix(m);
-    }
-
-    // todo: use 3 separate mixers instead
-
-    if (color == 0)
-      m.setScaleFactor(670, 100);  // 650-680
-    else if (color == 1)
-      m.setScaleFactor(820, 100); // 760-880
-    else if (color == 2)
-      m.setScaleFactor(920, 100); // 650-690 for others 880-960
-
-
-    // todo: review and optimize these mixer contexts
 
     INJECT_SHARED_bpos
     INJECT_SHARED_c0
     assert(color < 4);
-    uint32_t colorbpos = color << 3 | bpos; // 0..23 or 0..31
-    m.set(1 + colorbpos, 1 + 4 * 8);   // 1: account for padding zone
 
-    m.set(((lossQ / 40u) /*0..15*/) << 2 | color, 16 * 4);
-    m.set(((line & 7) << 5) | colorbpos, 256);
-    m.set(min(63, column[0]) + ((ctx[0] >> 3) & 0xC0), 256);
-    m.set(min(127, column[1]) + ((ctx[0] >> 2) & 0x180), 512);
-    m.set((ctx[0] & 0x7FC) | (bpos >> 1), 2048);
-    m.set(colorbpos + (static_cast<int>(c0 == ((0x100 | ((N + W + 1) >> 1)) >> (8 - bpos)))) * 32, 8 * 32);
-    m.set(min(color, stride - 1) * 64 + (x % stride) * 16 + (bpos >> 1), 6 * 64);
-    m.set((ctx[1] << 2) | (bpos >> 1), 1024);
+    const int bp = (UINT32_C(0x33322210) >> (bpos << 2)) & 0xF; // {bpos:0}->0  {bpos:1}->1  {bpos:2,3,4}->2  {bpos:5,6,7}->3
 
-    m.set(finalize64(hash(ctx[0], column[0] >> 3), 13), 8192);
-    m.set(min(255, (x + line) >> 5), 256);
+    m.set(1 + bpos, 1 + 8);   // 1: account for padding zone
+
+    m.set(lossQ4 /*0..7*/, 8);
+    m.set(((line & 7) << 3) | bpos, 8 * 8);
+
+    m.set(((x / stride) & 7) << 3 | (line & 7), 8 * 8);
+    m.set(((x / stride) & 15), 16);
+
+    int div3 = max((x / stride) >> 9, 3);
+    int div19 = max((x / stride) >> 8, 19);
+    m.set((x / stride / div3) & 511, 512);
+    m.set((x / stride / div19) & 255, 256);
+
+    int pred1 = 0x100 | ((N + W + 1) >> 1);
+    int pred2 = 0x100 | int8_t(N + W - NW);
+    int pred3 = 0x100 | int8_t(2 * N - NN);
+    int pred4 = 0x100 | int8_t(2 * W - WW);
+    m.set(
+      (c0 == (pred1 >> (8 - bpos))) << 6 |
+      (c0 == (pred2 >> (8 - bpos))) << 5 |
+      (c0 == (pred3 >> (8 - bpos))) << 4 |
+      (c0 == (pred4 >> (8 - bpos))) << 3 |
+      bpos, 16 * 8);
+    m.set(lossQ4 << 2 | bp, 8 * 4);
+    m.set((ctx[1] << 2) | bp, 1024);
+    m.set(ctx_best_direction << 3 | ctx_best_residual, 4 * 8);
+
+    m.set(((x / stride + line) >> 5) & 255, 256);
+
+    auto bestPredictorIndexW =
+      color == 0 ? bestPredictorIndexes(stride) : // W, same channel
+      bestPredictorIndexes(1);                    // current pixel, prev channel (co-located i.e. within the same pixel as what we predict)
+    auto bestPredictorIndexN = bestPredictorIndexes(w);                    // N, same channel
+
+    m.set(bestPredictorIndexW, (nDM + nOLS));
+    m.set(bestPredictorIndexN, (nDM + nOLS));
+
+    int bestErrN = GetPredErrAvg(bestPredictorIndexN);
+    int bestErrW = GetPredErrAvg(bestPredictorIndexW);
+    m.set(min(31, bestErrW) << 5 | min(31, bestErrN), 32 * 32);
+
+    auto bestPredictorIndexNE = bestPredictorIndexes(w + stride); // NW, same channel
+    auto bestPredictorIndexNW = bestPredictorIndexes(w - stride); // NE, same channel
+
+    int bestErrNE = GetPredErrAvg(bestPredictorIndexNE);
+    int bestErrNW = GetPredErrAvg(bestPredictorIndexNW);
+    m.set(min(31, bestErrNE) << 5 | min(31, bestErrNW), 32 * 32);
+
+    uint32_t rabsBits3 = ctx[0] >> 6; // the top 3 rabs bits
+    m.set(rabsBits3, 8);
+    uint32_t cmpBits6 = ctx[0] & 0x3F; // the 6 comparison bits
+    m.set(cmpBits6 << 3 | lossQ4, 64 * 8);
+
+    int trendN = 2 * N - NN;
+    int trendW = 2 * W - WW;
+    int trendNE = 2 * NE - NNEE;
+    int trendNW = 2 * NW - NNWW;
+
+    int trendMin = min(min(min(trendN, trendW), trendNE), trendNW);
+    int trendMax = max(max(max(trendN, trendW), trendNE), trendNW);
+
+    m.set((min(trendMax - trendMin, 255) >> 2) << 2 | (bpos >> 1), 64 * 4);
+
+    m.set(((p1 >> 5) << 5) | ((p2 >> 5) << 2) | (bpos >> 1), 8 * 8 * 4);
+
+
   }
   else {
     // padding zone

--- a/model/Image24BitModel.hpp
+++ b/model/Image24BitModel.hpp
@@ -14,10 +14,9 @@
  */
 class Image24BitModel {
 private:
-  static constexpr int nDM = 102;
+  static constexpr int nDM = 117;
   static constexpr int nOLS = 6;
-  static constexpr int nSM = nOLS;
-  static constexpr int nLSM = 43;
+  static constexpr int nLSM = 40;
   static constexpr int nCM = 30;
   Ilog *ilog = &Ilog::getInstance();
 
@@ -25,28 +24,29 @@ public:
   static constexpr int MIXERINPUTS =
     nLSM * LargeStationaryMap::MIXERINPUTS +
     (nDM * 3) * ResidualMap::MIXERINPUTS +
-    nSM * StationaryMap::MIXERINPUTS +
-    nCM * (ContextMap2::MIXERINPUTS + ContextMap2::MIXERINPUTS_RUN_STATS); // 909
-  static constexpr int MIXERCONTEXTS = (1 + 4 * 8) + (16 * 4) + 256 + 256 + 512 + 2048 + (8 * 32) + (6 * 64) + 1024 + 8192 + 256; // 13281
-  static constexpr int MIXERCONTEXTSETS = 11;
+    (nOLS * 2) * ResidualMap::MIXERINPUTS +
+    nCM * (ContextMap2::MIXERINPUTS + ContextMap2::MIXERINPUTS_RUN_STATS); // 996
+  static constexpr int MIXERCONTEXTS =
+    (1 + 8) + 8 + (8 * 8) + (8 * 8) + 16 + 512 + 256 + (16 * 8) + (8 * 4) + 1024 + (4 * 8) + 256
+    + (nDM + nOLS) + (nDM + nOLS) + 32 * 32 + 32 * 32 + 512 + 64 * 8 + 64 * 4 + 8 * 8 * 4; // 6231
+  static constexpr int MIXERCONTEXTSETS = 20; 
 
   Shared * const shared;
 
   // probability maps
   ContextMap2 cm;
-  ResidualMap mapR1, mapR2, mapR3;
+  ResidualMap mapR1, mapR2, mapR3, mapOLS1, mapOLS2;
   LargeStationaryMap mapL;
-  StationaryMap map[nSM];
 
-  // Per-predictor signed prediction error for each decoded pixel.
-  // Stores int8 (prediction - actual) for all nDM predictors at every pixel position.
+  // Per-predictor prediction error for each decoded pixel.
+  // Stores uint8 rabs(prediction - actual) for all nDM and nOLS predictors at every pixel position.
   // Read back via PredErr(ctxIndex, relX, relY) to estimate how well each predictor
-  // performed on causal neighbors (W, N, NW, NE of the current pixel, same color plane).
+  // performed on causal neighbors (W, N, NW, NE, WW, NN of the current pixel, same color plane).
   // The averaged absolute error across those neighbors feeds mapR1's histogram selection,
   // giving it a spatially-local, per-predictor confidence signal:
   // low value = predictor was accurate nearby.
   // Sized in init() to cover PRED_ERR_ROWS rows: nextPowerOf2(PRED_ERR_ROWS * w * nDM).
-  static constexpr size_t PRED_ERR_BUF_ROWS = 2; // two rows (including the current row) - we need to reach the predistion error of N, NW, NE
+  static constexpr size_t PRED_ERR_BUF_ROWS = 3; // three rows (including the current row) - we need to reach the prediction error of W, N, NW, NE, WW, NN
   RingBuffer<uint8_t> predErrBuf{ 0 };
 
   // Per-pixel accumulated decoding cost (loss), one byte per pixel per color plane.
@@ -56,12 +56,16 @@ public:
   // lossQ feeds mapR2's histogram selection,
   // allowing statistical maps to adapt to smooth vs. noisy/high-frequency regions.
   // Sized in init() to cover LOSS_BUF_ROWS rows: nextPowerOf2(LOSS_BUF_ROWS * w).
-  static constexpr size_t LOSS_BUF_ROWS = 3; // three rows (including the current row) - we need to reach the predistion error of NN
+  static constexpr size_t LOSS_BUF_ROWS = 3; // three rows (including the current row) - we need to reach the prediction error of NN
   RingBuffer<uint8_t> lossBuf{ 0 };
 
-  uint32_t loss = 0;  // decoding cost for the current byte, accumulated bit by bit (0..255 over 8 bits)
+  static constexpr size_t BEST_PRED_ROWS = 3; // three rows (including the current row) - we need to reach the prediction error of W, N and W+1, N+1
+  RingBuffer<uint8_t> bestPredictorIndexes { 0 };
+
+  uint32_t loss = 0;  // decoding cost for the current byte, accumulated bit by bit (0..1023 over 8 bits)
   uint32_t lossQ = 0; // sum of lossBuf[] over 6 causal neighbors (W, N, WW, NN, NW, NE), capped at 639;
                       // measures local image complexity: low = smooth region, high = noisy/detailed region
+  uint8_t lossQ4 = 0; // lossQ quantized to 3 bits
 
   // pixel neighborhood
   uint8_t WWWWWW = 0, WWWWW = 0, WWWW = 0, WWW = 0, WW = 0, W = 0;
@@ -80,9 +84,14 @@ public:
   int stride = 3;
   uint32_t ctx[2]{}, padding = 0, x = 0, w = 0, line = 0;
   uint32_t lastPos = 0;
-  int columns[2] = {1, 1}, column[2]{};
-  uint32_t predictions[nDM] = { 0 };
-  uint8_t pOLS[nOLS] = {0}; // Clipped OLS predictions (one per OLS predictor), used as input to StationaryMap.
+  uint32_t predictions[nDM + nOLS] = { 0 };
+
+  uint8_t ctx_best_direction{};
+  uint8_t ctx_best_residual{};
+  uint8_t ctx_best_direction_p1{};
+  uint8_t ctx_best_direction_p2{};
+
+  // OLS
 
   static constexpr float lambda[nOLS] = {0.98f, 0.87f, 0.9f, 0.8f, 0.9f, 0.7f};
   static constexpr int num[nOLS] = {32, 12, 15, 10, 14, 8};
@@ -100,13 +109,14 @@ public:
   const uint8_t **olsCtxs[nOLS] = {&olsCtx1[0], &olsCtx2[0], &olsCtx3[0], &olsCtx4[0], &olsCtx5[0], &olsCtx6[0]};
 
   Image24BitModel(Shared* const sh, uint64_t size);
-  void update();
 
   ALWAYS_INLINE uint8_t Px(int relX, int relY, int colorShift) const;
   ALWAYS_INLINE uint8_t Ls(int relX, int relY) const;
   ALWAYS_INLINE uint8_t GetPredErr(uint32_t ctxIndex, int relX, int relY) const;
+  ALWAYS_INLINE uint32_t GetPredErrAvg(const uint32_t predictorIndex) const;
   ALWAYS_INLINE void MakePrediction(int i, uint8_t base1, uint8_t base2, int prediction);
   ALWAYS_INLINE void MakePredictionC(int i, int prediction);
+  ALWAYS_INLINE void MakePredictionAvg(int i, int base1, int base2);
   ALWAYS_INLINE void MakePredictionTrend(int i, int base1, int other1, int base2);
   ALWAYS_INLINE void MakePredictionSmooth(int i, int base1, int other1, int base2);
 
@@ -115,5 +125,6 @@ public:
    */
   void init();
   void setParam(int width, uint32_t alpha0);
+  void update();
   void mix(Mixer &m);
 };

--- a/model/ImageModelsCommon.hpp
+++ b/model/ImageModelsCommon.hpp
@@ -42,15 +42,14 @@ static inline int gap(
 //signed difference between two 8-bit pixel values, quantized
 //used by 8-bit and 24-bit image models
 ALWAYS_INLINE
-uint8_t DiffQt(const uint8_t a, const uint8_t b, const uint8_t limit = 7) {
-  //assert(limit <= 7);
-  uint32_t d = abs(a - b);
+int DiffQt(const uint8_t a, const uint8_t b) {
+  int d = (a > b) ? (a - b) : (b - a);
   if (d <= 2)d = d;
   else if (d <= 5)d = 3; //3..5
   else if (d <= 9)d = 4; //6..9
   else if (d <= 14)d = 5; //10..14
   else if (d <= 23)d = 6; //15..23
   else d = 7; //24..255
-  const uint8_t sign = a > b ? 8 : 0;
-  return sign | min(d, limit);
+  const int sign = a > b ? 8 : 0;
+  return (sign | d);
 }

--- a/paq8px.cpp
+++ b/paq8px.cpp
@@ -8,7 +8,7 @@
 //////////////////////// Versioning ////////////////////////////////////////
 
 #define PROGNAME     "paq8px"
-#define PROGVERSION  "213"  //update version here before publishing your changes
+#define PROGVERSION  "214"  //update version here before publishing your changes
 #define PROGYEAR     "2026"
 
 


### PR DESCRIPTION
paq8px_v214

- Audio8BitModel: use ResidualMap instead of SmallStationaryContextMap.
- Image24BitModel: 
  - Use independent mixers per color channel.
  - Tuned mixer scaling factor and lower limit of learning rate, removed bias.
  - Use ResidualMap instead of StationaryMap for OLS.
  - Added and optimized contexts and mixer contexts.
